### PR TITLE
fix: update bucket lifecycle rules

### DIFF
--- a/terragrunt/aws/buckets/locals.tf
+++ b/terragrunt/aws/buckets/locals.tf
@@ -1,0 +1,37 @@
+locals {
+  # Remove all objects after expiry
+  lifecycle_expire_all = {
+    id      = "expire_all"
+    enabled = true
+    expiration = {
+      days                         = "30"
+      expired_object_delete_marker = true
+    }
+  }
+  # Cleanup old versions and incomplete uploads
+  lifecycle_remove_noncurrent_versions = {
+    id      = "remove_noncurrent_versions"
+    enabled = true
+    noncurrent_version_expiration = {
+      days = "30"
+    }
+    abort_incomplete_multipart_upload = {
+      days_after_initiation = "1"
+    }
+  }
+  # Transition objects to cheaper storage classes over time
+  lifecycle_transition_storage = {
+    id      = "transition_storage"
+    enabled = true
+    transitions = [
+      {
+        days          = "90"
+        storage_class = "STANDARD_IA"
+      },
+      {
+        days          = "180"
+        storage_class = "GLACIER"
+      }
+    ]
+  }
+}

--- a/terragrunt/aws/buckets/locals.tf
+++ b/terragrunt/aws/buckets/locals.tf
@@ -10,20 +10,18 @@ locals {
   }
   # Cleanup old versions and incomplete uploads
   lifecycle_remove_noncurrent_versions = {
-    id      = "remove_noncurrent_versions"
-    enabled = true
+    id                                     = "remove_noncurrent_versions"
+    enabled                                = true
+    abort_incomplete_multipart_upload_days = "7"
     noncurrent_version_expiration = {
       days = "30"
-    }
-    abort_incomplete_multipart_upload = {
-      days_after_initiation = "1"
     }
   }
   # Transition objects to cheaper storage classes over time
   lifecycle_transition_storage = {
     id      = "transition_storage"
     enabled = true
-    transitions = [
+    transition = [
       {
         days          = "90"
         storage_class = "STANDARD_IA"

--- a/terragrunt/aws/buckets/s3.tf
+++ b/terragrunt/aws/buckets/s3.tf
@@ -60,12 +60,20 @@ module "log_bucket" {
   bucket_name       = "cds-data-lake-bucket-logs-${var.env}"
   versioning_status = "Enabled"
 
-  lifecycle_rule = {
-    "lifecycle_rule" : {
-      "enabled" : "true",
-      "expiration" : { "days" : "30" }
+  lifecycle_rule = [{
+    id      = "expire_logs"
+    enabled = true
+    expiration = {
+      days                         = "30"
+      expired_object_delete_marker = true
     }
-  }
+    noncurrent_version_expiration = {
+      days = "30"
+    }
+    abort_incomplete_multipart_upload = {
+      days_after_initiation = "7"
+    }
+  }]
 
   billing_tag_value = var.billing_tag_value
 }

--- a/terragrunt/aws/buckets/s3.tf
+++ b/terragrunt/aws/buckets/s3.tf
@@ -11,6 +11,11 @@ module "raw_bucket" {
     target_prefix = "raw/"
   }
 
+  lifecycle_rule = [
+    local.lifecycle_remove_noncurrent_versions,
+    local.lifecycle_transition_storage
+  ]
+
   versioning = {
     enabled = true
   }
@@ -28,6 +33,10 @@ module "transformed_bucket" {
     target_bucket = module.log_bucket.s3_bucket_id
     target_prefix = "transformed/"
   }
+
+  lifecycle_rule = [
+    local.lifecycle_remove_noncurrent_versions
+  ]
 
   versioning = {
     enabled = true
@@ -47,6 +56,10 @@ module "curated_bucket" {
     target_prefix = "curated/"
   }
 
+  lifecycle_rule = [
+    local.lifecycle_remove_noncurrent_versions
+  ]
+
   versioning = {
     enabled = true
   }
@@ -60,20 +73,10 @@ module "log_bucket" {
   bucket_name       = "cds-data-lake-bucket-logs-${var.env}"
   versioning_status = "Enabled"
 
-  lifecycle_rule = [{
-    id      = "expire_logs"
-    enabled = true
-    expiration = {
-      days                         = "30"
-      expired_object_delete_marker = true
-    }
-    noncurrent_version_expiration = {
-      days = "30"
-    }
-    abort_incomplete_multipart_upload = {
-      days_after_initiation = "7"
-    }
-  }]
+  lifecycle_rule = [
+    local.lifecycle_expire_all,
+    local.lifecycle_remove_noncurrent_versions
+  ]
 
   billing_tag_value = var.billing_tag_value
 }

--- a/terragrunt/aws/buckets/s3.tf
+++ b/terragrunt/aws/buckets/s3.tf
@@ -2,7 +2,7 @@
 # Holds exported data before transformation
 #
 module "raw_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.7"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=4768da635c66d3333538835b215887cb3c7e3036"
   bucket_name       = "cds-data-lake-raw-${var.env}"
   billing_tag_value = var.billing_tag_value
 
@@ -25,7 +25,7 @@ module "raw_bucket" {
 # ETL jobs process the `Raw` bucket and store the transformed data here
 #
 module "transformed_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.7"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=4768da635c66d3333538835b215887cb3c7e3036"
   bucket_name       = "cds-data-lake-transformed-${var.env}"
   billing_tag_value = var.billing_tag_value
 
@@ -47,7 +47,7 @@ module "transformed_bucket" {
 # Holds enriched data that has been created by combining multiple transformed datasets
 #
 module "curated_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.7"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=4768da635c66d3333538835b215887cb3c7e3036"
   bucket_name       = "cds-data-lake-curated-${var.env}"
   billing_tag_value = var.billing_tag_value
 

--- a/terragrunt/aws/buckets/s3.tf
+++ b/terragrunt/aws/buckets/s3.tf
@@ -2,7 +2,7 @@
 # Holds exported data before transformation
 #
 module "raw_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=4768da635c66d3333538835b215887cb3c7e3036"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.8"
   bucket_name       = "cds-data-lake-raw-${var.env}"
   billing_tag_value = var.billing_tag_value
 
@@ -25,7 +25,7 @@ module "raw_bucket" {
 # ETL jobs process the `Raw` bucket and store the transformed data here
 #
 module "transformed_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=4768da635c66d3333538835b215887cb3c7e3036"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.8"
   bucket_name       = "cds-data-lake-transformed-${var.env}"
   billing_tag_value = var.billing_tag_value
 
@@ -47,7 +47,7 @@ module "transformed_bucket" {
 # Holds enriched data that has been created by combining multiple transformed datasets
 #
 module "curated_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=4768da635c66d3333538835b215887cb3c7e3036"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.8"
   bucket_name       = "cds-data-lake-curated-${var.env}"
   billing_tag_value = var.billing_tag_value
 
@@ -69,7 +69,7 @@ module "curated_bucket" {
 # Bucket access logs, stored for 30 days
 #
 module "log_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v9.6.7"
+  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v9.6.8"
   bucket_name       = "cds-data-lake-bucket-logs-${var.env}"
   versioning_status = "Enabled"
 


### PR DESCRIPTION
# Summary
Update the S3 bucket lifecycle rules:
1. Expire non-current versions after 30 days.
2. Remove failed multipart uploads.
3. Move `Raw` bucket objects to cheaper storage over time.

# Related
- https://github.com/cds-snc/platform-core-services/issues/609