### PR TITLE
fix: remove invalid expire lifecycle policy

### DIFF
--- a/terragrunt/aws/buckets/locals.tf
+++ b/terragrunt/aws/buckets/locals.tf
@@ -4,8 +4,7 @@ locals {
     id      = "expire_all"
     enabled = true
     expiration = {
-      days                         = "30"
-      expired_object_delete_marker = true
+      days = "30"
     }
   }
   # Cleanup old versions and incomplete uploads


### PR DESCRIPTION
# Summary
Remove the expired object delete marker rule as it is not applicable with this lifecycle rule and is causing a TF plan flip-flop.
