### PR TITLE
feat: add Glue database and crawlers for org data

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: terragrunt/env/production/buckets
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Terragrunt apply glue
+        working-directory: terragrunt/env/production/glue
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Report deployment to Sentinel
         if: always()
         uses: cds-snc/sentinel-forward-data-action@main

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -48,3 +48,12 @@ jobs:
           comment-title: "Production: buckets"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
+
+      - name: Terragrunt plan glue
+        uses: cds-snc/terraform-plan@25afd759b2ada46a94b011fab7a81963c4f3a61a # v3.3.0
+        with:
+          directory: "terragrunt/env/production/glue"
+          comment-delete: "true"
+          comment-title: "Production: glue"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"

--- a/terragrunt/aws/buckets/outputs.tf
+++ b/terragrunt/aws/buckets/outputs.tf
@@ -1,0 +1,29 @@
+output "curated_bucket_arn" {
+  description = "ARN of the S3 Curated data bucket."
+  value       = module.curated_bucket.s3_bucket_arn
+}
+
+output "curated_bucket_name" {
+  description = "Name of the S3 Curated data bucket."
+  value       = module.curated_bucket.s3_bucket_id
+}
+
+output "raw_bucket_arn" {
+  description = "ARN of the S3 Raw data bucket."
+  value       = module.raw_bucket.s3_bucket_arn
+}
+
+output "raw_bucket_name" {
+  description = "Name of the S3 Raw data bucket."
+  value       = module.raw_bucket.s3_bucket_id
+}
+
+output "transformed_bucket_arn" {
+  description = "ARN of the S3 Transformed data bucket."
+  value       = module.transformed_bucket.s3_bucket_arn
+}
+
+output "transformed_bucket_name" {
+  description = "Name of the S3 Transformed data bucket."
+  value       = module.transformed_bucket.s3_bucket_id
+}

--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -1,3 +1,21 @@
+resource "aws_glue_security_configuration" "s3_encryption" {
+  name = "s3-encryption"
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      s3_encryption_mode = "SSE-S3"
+    }
+  }
+}
+
 #
 # Cost and Usage Report
 #
@@ -5,7 +23,9 @@ resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
   name          = "Cost and Usage Report 2.0"
   database_name = aws_glue_catalog_database.operations_aws_production.name
   table_prefix  = "cost_usage_report_"
-  role          = aws_iam_role.glue_crawler.arn
+
+  role                   = aws_iam_role.glue_crawler.arn
+  security_configuration = aws_glue_security_configuration.s3_encryption.name
 
   s3_target {
     path = "s3://${var.raw_bucket_name}/operations/aws/cost-usage-report"
@@ -33,7 +53,9 @@ resource "aws_glue_crawler" "operations_aws_production_account_tags" {
   name          = "Organization Account Tags"
   database_name = aws_glue_catalog_database.operations_aws_production.name
   table_prefix  = "org_"
-  role          = aws_iam_role.glue_crawler.arn
+
+  role                   = aws_iam_role.glue_crawler.arn
+  security_configuration = aws_glue_security_configuration.s3_encryption.name
 
   s3_target {
     path = "s3://${var.raw_bucket_name}/operations/aws/organization"

--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -1,0 +1,55 @@
+#
+# Cost and Usage Report
+#
+resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
+  name          = "Cost and Usage Report 2.0"
+  database_name = aws_glue_catalog_database.operations_aws_production.name
+  table_prefix  = "cost_usage_report_"
+  role          = aws_iam_role.glue_crawler.arn
+
+  s3_target {
+    path = "s3://${var.raw_bucket_name}/operations/aws/cost-usage-report"
+  }
+
+  configuration = jsonencode(
+    {
+      CrawlerOutput = {
+        Tables = {
+          TableThreshold = 2
+        }
+      }
+      CreatePartitionIndex = true
+      Version              = 1
+  })
+
+  # TODO: enable schedule once job has been tested
+  # schedule = "cron(00 7 1 * ? *)" # Create the new month's partition key
+}
+
+#
+# Organization Account Tags
+#
+resource "aws_glue_crawler" "operations_aws_production_account_tags" {
+  name          = "Organization Account Tags"
+  database_name = aws_glue_catalog_database.operations_aws_production.name
+  table_prefix  = "org_"
+  role          = aws_iam_role.glue_crawler.arn
+
+  s3_target {
+    path = "s3://${var.raw_bucket_name}/operations/aws/organization"
+  }
+
+  configuration = jsonencode(
+    {
+      CrawlerOutput = {
+        Tables = {
+          TableThreshold = 1
+        }
+      }
+      CreatePartitionIndex = true
+      Version              = 1
+  })
+
+  # TODO: enable schedule once job has been tested
+  # schedule = "cron(00 13 * * ? *)" # Pickup new accounts each day
+}

--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -1,5 +1,5 @@
-resource "aws_glue_security_configuration" "s3_encryption" {
-  name = "s3-encryption"
+resource "aws_glue_security_configuration" "encryption_at_rest" {
+  name = "encryption-at-rest"
 
   encryption_configuration {
     cloudwatch_encryption {
@@ -8,7 +8,7 @@ resource "aws_glue_security_configuration" "s3_encryption" {
     }
 
     job_bookmarks_encryption {
-      job_bookmarks_encryption_mode = "SSE-KMS"
+      job_bookmarks_encryption_mode = "CSE-KMS"
       kms_key_arn                   = aws_kms_key.aws_glue.arn
     }
 
@@ -27,7 +27,7 @@ resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
   table_prefix  = "cost_usage_report_"
 
   role                   = aws_iam_role.glue_crawler.arn
-  security_configuration = aws_glue_security_configuration.s3_encryption.name
+  security_configuration = aws_glue_security_configuration.encryption_at_rest.name
 
   s3_target {
     path = "s3://${var.raw_bucket_name}/operations/aws/cost-usage-report"
@@ -57,7 +57,7 @@ resource "aws_glue_crawler" "operations_aws_production_account_tags" {
   table_prefix  = "org_"
 
   role                   = aws_iam_role.glue_crawler.arn
-  security_configuration = aws_glue_security_configuration.s3_encryption.name
+  security_configuration = aws_glue_security_configuration.encryption_at_rest.name
 
   s3_target {
     path = "s3://${var.raw_bucket_name}/operations/aws/organization"

--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -3,11 +3,13 @@ resource "aws_glue_security_configuration" "s3_encryption" {
 
   encryption_configuration {
     cloudwatch_encryption {
-      cloudwatch_encryption_mode = "DISABLED"
+      cloudwatch_encryption_mode = "SSE-KMS"
+      kms_key_arn                = aws_kms_key.aws_glue.arn
     }
 
     job_bookmarks_encryption {
-      job_bookmarks_encryption_mode = "DISABLED"
+      job_bookmarks_encryption_mode = "SSE-KMS"
+      kms_key_arn                   = aws_kms_key.aws_glue.arn
     }
 
     s3_encryption {

--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -1,0 +1,4 @@
+resource "aws_glue_catalog_database" "operations_aws_production" {
+  name        = "operations_aws_production"
+  description = "Data source path: /operations/aws/*"
+}

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -49,4 +49,23 @@ data "aws_iam_policy_document" "glue_crawler" {
       "${var.transformed_bucket_arn}/*"
     ]
   }
+
+  statement {
+    sid    = "UseGlueKey"
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant",
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:ReEncryptFrom",
+      "kms:ReEncryptTo",
+      "kms:RetireGrant"
+    ]
+    resources = [
+      aws_kms_key.aws_glue.arn
+    ]
+  }
 }

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -3,8 +3,24 @@
 #
 resource "aws_iam_role" "glue_crawler" {
   name               = "AWSGlueCrawler-DataLake"
-  assume_role_policy = data.aws_iam_policy_document.glue_crawler_assume.json
   path               = "/service-role/"
+  assume_role_policy = data.aws_iam_policy_document.glue_crawler_assume.json
+}
+
+resource "aws_iam_policy" "glue_crawler" {
+  name   = "AWSGlueCrawler-DataLake"
+  path   = "/service-role/"
+  policy = data.aws_iam_policy_document.glue_crawler.json
+}
+
+resource "aws_iam_role_policy_attachment" "glue_crawler" {
+  policy_arn = aws_iam_policy.glue_crawler.arn
+  role       = aws_iam_role.glue_crawler.name
+}
+
+resource "aws_iam_role_policy_attachment" "aws_glue_service_role" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  role       = aws_iam_role.glue_crawler.name
 }
 
 data "aws_iam_policy_document" "glue_crawler_assume" {
@@ -19,23 +35,6 @@ data "aws_iam_policy_document" "glue_crawler_assume" {
       ]
     }
   }
-}
-
-resource "aws_iam_role_policy_attachment" "aws_glue_service_role" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
-  role       = aws_iam_role.glue_crawler.name
-}
-
-resource "aws_iam_policy" "glue_crawler" {
-  name        = "AWSGlueCrawler-DataLake"
-  policy      = data.aws_iam_policy_document.glue_s3_crawler.json
-  description = "This policy will be used by the AWS Glue Crawler."
-  path        = "/service-role/"
-}
-
-resource "aws_iam_role_policy_attachment" "glue_crawler" {
-  policy_arn = aws_iam_policy.glue_s3_crawler.arn
-  role       = aws_iam_role.glue_s3_crawler.name
 }
 
 data "aws_iam_policy_document" "glue_crawler" {

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -1,0 +1,53 @@
+#
+# Glue crawler role
+#
+resource "aws_iam_role" "glue_crawler" {
+  name               = "AWSGlueCrawler-DataLake"
+  assume_role_policy = data.aws_iam_policy_document.glue_crawler_assume.json
+  path               = "/service-role/"
+}
+
+data "aws_iam_policy_document" "glue_crawler_assume" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "glue.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "aws_glue_service_role" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  role       = aws_iam_role.glue_crawler.name
+}
+
+resource "aws_iam_policy" "glue_crawler" {
+  name        = "AWSGlueCrawler-DataLake"
+  policy      = data.aws_iam_policy_document.glue_s3_crawler.json
+  description = "This policy will be used by the AWS Glue Crawler."
+  path        = "/service-role/"
+}
+
+resource "aws_iam_role_policy_attachment" "glue_crawler" {
+  policy_arn = aws_iam_policy.glue_s3_crawler.arn
+  role       = aws_iam_role.glue_s3_crawler.name
+}
+
+data "aws_iam_policy_document" "glue_crawler" {
+  statement {
+    sid = "ReadDataLakeS3Buckets"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${var.curated_bucket_arn}/*",
+      "${var.raw_bucket_arn}/*",
+      "${var.transformed_bucket_arn}/*"
+    ]
+  }
+}

--- a/terragrunt/aws/glue/kms.tf
+++ b/terragrunt/aws/glue/kms.tf
@@ -15,7 +15,7 @@ resource "aws_kms_key" "aws_glue" {
 
 resource "aws_kms_alias" "data_export" {
   name          = "alias/aws-glue"
-  target_key_id = aws_kms_key.data_export.key_id
+  target_key_id = aws_kms_key.aws_glue.key_id
 }
 
 data "aws_iam_policy_document" "aws_glue" {

--- a/terragrunt/aws/glue/kms.tf
+++ b/terragrunt/aws/glue/kms.tf
@@ -1,0 +1,56 @@
+locals {
+  glue_role_arns = [
+    aws_iam_role.glue_crawler.arn,
+  ]
+}
+
+#
+# KMS key used by AWS Glue for encryption
+#
+resource "aws_kms_key" "aws_glue" {
+  description         = "AWS Glue encryption key for data at rest"
+  enable_key_rotation = "true"
+  policy              = data.aws_iam_policy_document.aws_glue.json
+}
+
+resource "aws_kms_alias" "data_export" {
+  name          = "alias/aws-glue"
+  target_key_id = aws_kms_key.data_export.key_id
+}
+
+data "aws_iam_policy_document" "aws_glue" {
+  # checkov:skip=CKV_AWS_109: false-positive,`resources = ["*"]` references KMS key policy is attached to
+  # checkov:skip=CKV_AWS_111: false-positive,`resources = ["*"]` references KMS key policy is attached to
+
+  # Allow this account to use the key
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = [var.account_id]
+    }
+  }
+
+  # Allow product accounts to use the key for encryption
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:ReEncryptFrom",
+      "kms:ReEncryptTo",
+      "kms:CreateGrant",
+      "kms:DescribeKey",
+      "kms:RetireGrant"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = local.glue_role_arns
+    }
+  }
+}

--- a/terragrunt/aws/glue/variables.tf
+++ b/terragrunt/aws/glue/variables.tf
@@ -1,0 +1,29 @@
+variable "curated_bucket_arn" {
+  description = "The ARN of the Curated bucket"
+  type        = string
+}
+
+variable "curated_bucket_name" {
+  description = "The name of the Curated bucket"
+  type        = string
+}
+
+variable "raw_bucket_arn" {
+  description = "The ARN of the Raw bucket"
+  type        = string
+}
+
+variable "raw_bucket_name" {
+  description = "The name of the Raw bucket"
+  type        = string
+}
+
+variable "transformed_bucket_arn" {
+  description = "The ARN of the Transformed bucket"
+  type        = string
+}
+
+variable "transformed_bucket_name" {
+  description = "The name of the Transformed bucket"
+  type        = string
+}

--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -14,9 +14,9 @@ provider "aws" {
   allowed_account_ids = [var.account_id]
 
   default_tags {
-   tags = {
-     CostCentre = "PlatformDataLake"
-     Terraform  = true
-   }
- }
+    tags = {
+      CostCentre = "PlatformDataLake"
+      Terraform  = true
+    }
+  }
 }

--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -12,4 +12,11 @@ terraform {
 provider "aws" {
   region              = var.region
   allowed_account_ids = [var.account_id]
+
+  default_tags {
+   tags = {
+     CostCentre = "PlatformDataLake"
+     Terraform  = true
+   }
+ }
 }

--- a/terragrunt/env/production/glue/terragrunt.hcl
+++ b/terragrunt/env/production/glue/terragrunt.hcl
@@ -1,0 +1,34 @@
+terraform {
+  source = "../../../aws//glue"
+}
+
+dependencies {
+  paths = ["../buckets"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    curated_bucket_arn      = "arn:aws:s3:::mock-curated-bucket"
+    curated_bucket_name     = "mock-curated-bucket"
+    raw_bucket_arn          = "arn:aws:s3:::mock-raw-bucket"
+    raw_bucket_name         = "mock-raw-bucket"
+    transformed_bucket_arn  = "arn:aws:s3:::mock-transformed-bucket"
+    transformed_bucket_name = "mock-transformed-bucket"
+  }
+}
+
+inputs = {
+  curated_bucket_arn      = dependency.buckets.outputs.curated_bucket_arn
+  curated_bucket_name     = dependency.buckets.outputs.curated_bucket_name
+  raw_bucket_arn          = dependency.buckets.outputs.raw_bucket_arn
+  raw_bucket_name         = dependency.buckets.outputs.raw_bucket_name
+  transformed_bucket_arn  = dependency.buckets.outputs.transformed_bucket_arn
+  transformed_bucket_name = dependency.buckets.outputs.transformed_bucket_name
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Add a `glue` module that contains the resources needed to setup the AWS Glue database and crawlers for the organization data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610