### PR TITLE
fix: Glue KMS key policy allow CloudWatch

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -68,4 +68,18 @@ data "aws_iam_policy_document" "glue_crawler" {
       aws_kms_key.aws_glue.arn
     ]
   }
+
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    actions = [
+      "logs:AssociateKmsKey"
+    ]
+    resources = [
+      aws_kms_key.aws_glue.arn
+    ]
+  }
 }

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -70,16 +70,13 @@ data "aws_iam_policy_document" "glue_crawler" {
   }
 
   statement {
+    sid    = "AssociateKmsKey"
     effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["logs.${var.region}.amazonaws.com"]
-    }
     actions = [
       "logs:AssociateKmsKey"
     ]
     resources = [
-      aws_kms_key.aws_glue.arn
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/crawlers-role/service-role/${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}:*"
     ]
   }
 }

--- a/terragrunt/aws/glue/kms.tf
+++ b/terragrunt/aws/glue/kms.tf
@@ -24,18 +24,39 @@ data "aws_iam_policy_document" "aws_glue" {
 
   # Allow this account to use the key
   statement {
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
+    effect = "Allow"
     principals {
       type        = "AWS"
       identifiers = [var.account_id]
     }
+    actions   = ["kms:*"]
+    resources = ["*"]
   }
 
-  # Allow product accounts to use the key for encryption
+  # Allow CloudWatch Logs to use the key for encryption
   statement {
     effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+  }
+
+  # Allow Glue roles to use the key for encryption
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = local.glue_role_arns
+    }
     actions = [
       "kms:Encrypt",
       "kms:Decrypt",
@@ -48,9 +69,5 @@ data "aws_iam_policy_document" "aws_glue" {
       "kms:RetireGrant"
     ]
     resources = ["*"]
-    principals {
-      type        = "AWS"
-      identifiers = local.glue_role_arns
-    }
   }
 }

--- a/terragrunt/env/production/glue/.terraform.lock.hcl
+++ b/terragrunt/env/production/glue/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.75.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Vp6AJuCkdX4e1r8twlZmiBxO82N24+ytjVNQUBePy/s=",
+    "zh:01b01b132b70df918f735898f1ad012ab3033d1b909b2e38950d16964d94c084",
+    "zh:28bc6ee7b0c88b1a48f315509ad390fb1e8f39bebe0f7a43c22b1a63825251d1",
+    "zh:31f9043a4c3538883ab9b9d3b399dae62e4552251e6a2b1da13ec3a2018a027d",
+    "zh:47451c295ffbddd19679a41d728f0942486d6de0d9206418d9593dda5a20c120",
+    "zh:5204c1a9f41dcc10e38879d41d95d95fdbb10527f613c129603137b1dbe99777",
+    "zh:64c3165a6019045782c8ad2a40d6fa4253d44dba67a5a971a81791cff5a9d3d5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a5788f78da2f0ac78f99ca2a4c489c041654bec992f3183fd0b972e0554f91e9",
+    "zh:aed486e3b24e9f82543bf558b2a7eade4a905608060fac1284145c00ff63d3e2",
+    "zh:b42523c409940a9c3866f4973c8251b96e5f3a0934230849c533a04b95854965",
+    "zh:b570353eeb97b3ed1b423a6f67857a7a3c1c47c9907e45a81c3df186a2fd88d0",
+    "zh:bf05df84199cbc776a878f920f6be4d27737f2de204f80794e6a652d49692f0d",
+    "zh:c27133287d20620244de95f4c2438135e60c057e0891a3ec97539c990f7ebdec",
+    "zh:c59143082fe8e4f5d5b0676472b8b0e24c2a2f1ede622a64f9f24639382d4b03",
+    "zh:ebe01c3b7a85deebc10b4081097dd6e8b4c79b7c13a20acb099bd17ff06afcb7",
+  ]
+}


### PR DESCRIPTION
# Summary
Update the Glue IAM and KMS key policies to allow CloudWatch to use the key for log encryption.

⚠️ This was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610