### PR TITLE
fix: alarm module dependency on glue

### DIFF
--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -7,7 +7,7 @@ dependencies {
 }
 
 dependency "glue" {
-  config_path                             = "../buckets"
+  config_path                             = "../glue"
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {


### PR DESCRIPTION
# Summary
Update the Terragrunt config to correctly point to the glue module.

# Related
- #15 
- https://github.com/cds-snc/platform-core-services/issues/612