### PR TITLE
fix: Glue ETL role permissions

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -121,7 +121,9 @@ data "aws_iam_policy_document" "glue_kms" {
       "logs:AssociateKmsKey"
     ]
     resources = [
-      "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.glue_crawler_log_group_name}:*"
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.glue_crawler_log_group_name}*",
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.glue_etl_log_group_name}*",
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/sessions/*",
     ]
   }
 }

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -1,3 +1,4 @@
 locals {
   glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"
+  glue_etl_log_group_name     = "/aws-glue/jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"
 }


### PR DESCRIPTION
# Summary
Update the Glue ETL IAM role to allow it to associate a KMS key with the Glue CloudWatch log group.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610