### PR TITLE
feat: add Cost and Usage Glue visual ETL job

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -22,7 +22,7 @@ resource "aws_glue_security_configuration" "encryption_at_rest" {
 # Cost and Usage Report
 #
 resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
-  name          = "Cost and Usage Report 2.0"
+  name          = "Operations / AWS / Cost and Usage Report"
   description   = "Classify the AWS Organization Cost and Usage Report data"
   database_name = aws_glue_catalog_database.operations_aws_production.name
   table_prefix  = "cost_usage_report_"
@@ -52,7 +52,7 @@ resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
 # Organization Account Tags
 #
 resource "aws_glue_crawler" "operations_aws_production_account_tags" {
-  name          = "Organization Account Tags"
+  name          = "Operations / AWS / Organization / Account Tags"
   description   = "Classify the AWS Organization account tag extract"
   database_name = aws_glue_catalog_database.operations_aws_production.name
   table_prefix  = "account_tags_"

--- a/terragrunt/aws/glue/etl/operations/aws/cost-and-usage-report.json
+++ b/terragrunt/aws/glue/etl/operations/aws/cost-and-usage-report.json
@@ -1,0 +1,1577 @@
+{
+	"jobConfig": {
+		"name": "Operations / AWS / Cost and Usage Report",
+		"description": "Joins the AWS Cost and Usage Report data with the Organization account tags so that cost can be viewed by business unit.",
+		"role": "arn:aws:iam::739275439843:role/service-role/AWSGlueETL-DataLake",
+		"command": "glueetl",
+		"version": "4.0",
+		"runtime": null,
+		"workerType": "G.1X",
+		"numberOfWorkers": 10,
+		"maxCapacity": 10,
+		"jobRunQueuingEnabled": false,
+		"maxRetries": 0,
+		"timeout": 120,
+		"maxConcurrentRuns": 1,
+		"security": "encryption-at-rest",
+		"scriptName": " Cost and Usage Report.py",
+		"scriptLocation": "s3://aws-glue-assets-739275439843-ca-central-1/scripts/Operations / AWS /",
+		"language": "python-3",
+		"spark": true,
+		"sparkConfiguration": "standard",
+		"jobParameters": [],
+		"tags": [],
+		"jobMode": "VISUAL_MODE",
+		"createdOn": "2024-11-12T16:36:58.812Z",
+		"developerMode": false,
+		"connectionsList": [],
+		"temporaryDirectory": "s3://aws-glue-assets-739275439843-ca-central-1/temporary/",
+		"etlAutoScaling": true,
+		"logging": true,
+		"glueHiveMetastore": true,
+		"etlAutoTuning": true,
+		"metrics": true,
+		"observabilityMetrics": true,
+		"bookmark": "job-bookmark-disable",
+		"sparkPath": "s3://aws-glue-assets-739275439843-ca-central-1/sparkHistoryLogs/",
+		"flexExecution": false,
+		"minFlexWorkers": null,
+		"sourceControlDetails": {
+			"Provider": "NONE",
+			"Repository": "",
+			"Branch": "",
+			"Folder": "glue-etl",
+			"LastCommitId": "c708a0d9eec25a6ef215ce7d385967e9bda2241e"
+		},
+		"maintenanceWindow": null,
+		"pythonPath": "",
+		"securityConfigEncryption": {
+			"serverSideEncryption": "AES256"
+		}
+	},
+	"dag": {
+		"node-1731428848266": {
+			"nodeId": "node-1731428848266",
+			"dataPreview": false,
+			"previewAmount": 0,
+			"inputs": [],
+			"name": "Cost and Usage Report",
+			"generatedNodeName": "CostandUsageReport_node1731428848266",
+			"classification": "DataSource",
+			"type": "Catalog",
+			"isCatalog": true,
+			"database": "operations_aws_production",
+			"table": "cost_usage_report_data",
+			"calculatedType": "",
+			"runtimeParameters": [],
+			"codeGenVersion": 2
+		},
+		"node-1731523780914": {
+			"nodeId": "node-1731523780914",
+			"dataPreview": false,
+			"previewAmount": 0,
+			"inputs": [
+				"node-1731523763363",
+				"node-1731428848266"
+			],
+			"name": "Join",
+			"generatedNodeName": "Join_node1731523780914",
+			"classification": "Transform",
+			"type": "Join",
+			"joinType": "equijoin",
+			"columns": [
+				{
+					"from": "node-1731523763363",
+					"keys": [
+						"id"
+					]
+				},
+				{
+					"from": "node-1731428848266",
+					"keys": [
+						"line_item_usage_account_id"
+					]
+				}
+			],
+			"columnConditions": [
+				"="
+			],
+			"parentsValid": true,
+			"calculatedType": "",
+			"codeGenVersion": 2
+		},
+		"node-1731429060956": {
+			"nodeId": "node-1731429060956",
+			"dataPreview": false,
+			"previewAmount": 0,
+			"inputs": [
+				"node-1731523780914"
+			],
+			"name": "Change Schema",
+			"generatedNodeName": "ChangeSchema_node1731429060956",
+			"classification": "Transform",
+			"type": "ApplyMapping",
+			"mapping": [
+				{
+					"toKey": "id",
+					"fromPath": [
+						"id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "arn",
+					"fromPath": [
+						"arn"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "email",
+					"fromPath": [
+						"email"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "name",
+					"fromPath": [
+						"name"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "status",
+					"fromPath": [
+						"status"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "joinedmethod",
+					"fromPath": [
+						"joinedmethod"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "joinedtimestamp",
+					"fromPath": [
+						"joinedtimestamp"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "tag_env",
+					"fromPath": [
+						"tag_env"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "tag_business_unit",
+					"fromPath": [
+						"tag_business_unit"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "tag_product",
+					"fromPath": [
+						"tag_product"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_bill_type",
+					"fromPath": [
+						"bill_bill_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_billing_entity",
+					"fromPath": [
+						"bill_billing_entity"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_billing_period_end_date",
+					"fromPath": [
+						"bill_billing_period_end_date"
+					],
+					"toType": "timestamp",
+					"fromType": "timestamp",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_billing_period_start_date",
+					"fromPath": [
+						"bill_billing_period_start_date"
+					],
+					"toType": "timestamp",
+					"fromType": "timestamp",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_invoice_id",
+					"fromPath": [
+						"bill_invoice_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_invoicing_entity",
+					"fromPath": [
+						"bill_invoicing_entity"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_payer_account_id",
+					"fromPath": [
+						"bill_payer_account_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "bill_payer_account_name",
+					"fromPath": [
+						"bill_payer_account_name"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "cost_category",
+					"fromPath": [
+						"cost_category"
+					],
+					"toType": "object",
+					"fromType": "object",
+					"dropped": true,
+					"children": [
+						{
+							"toKey": "string",
+							"fromPath": [
+								"cost_category",
+								"string"
+							],
+							"toType": "string",
+							"fromType": "string",
+							"dropped": true,
+							"children": null
+						}
+					]
+				},
+				{
+					"toKey": "discount",
+					"fromPath": [
+						"discount"
+					],
+					"toType": "object",
+					"fromType": "object",
+					"dropped": true,
+					"children": [
+						{
+							"toKey": "string",
+							"fromPath": [
+								"discount",
+								"string"
+							],
+							"toType": "double",
+							"fromType": "double",
+							"dropped": true,
+							"children": null
+						}
+					]
+				},
+				{
+					"toKey": "discount_bundled_discount",
+					"fromPath": [
+						"discount_bundled_discount"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "discount_total_discount",
+					"fromPath": [
+						"discount_total_discount"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "identity_line_item_id",
+					"fromPath": [
+						"identity_line_item_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "identity_time_interval",
+					"fromPath": [
+						"identity_time_interval"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_availability_zone",
+					"fromPath": [
+						"line_item_availability_zone"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_blended_cost",
+					"fromPath": [
+						"line_item_blended_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_blended_rate",
+					"fromPath": [
+						"line_item_blended_rate"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_currency_code",
+					"fromPath": [
+						"line_item_currency_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_legal_entity",
+					"fromPath": [
+						"line_item_legal_entity"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_line_item_description",
+					"fromPath": [
+						"line_item_line_item_description"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_line_item_type",
+					"fromPath": [
+						"line_item_line_item_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_net_unblended_cost",
+					"fromPath": [
+						"line_item_net_unblended_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_net_unblended_rate",
+					"fromPath": [
+						"line_item_net_unblended_rate"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_normalization_factor",
+					"fromPath": [
+						"line_item_normalization_factor"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_normalized_usage_amount",
+					"fromPath": [
+						"line_item_normalized_usage_amount"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_operation",
+					"fromPath": [
+						"line_item_operation"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_product_code",
+					"fromPath": [
+						"line_item_product_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_resource_id",
+					"fromPath": [
+						"line_item_resource_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_tax_type",
+					"fromPath": [
+						"line_item_tax_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_unblended_cost",
+					"fromPath": [
+						"line_item_unblended_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_unblended_rate",
+					"fromPath": [
+						"line_item_unblended_rate"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_usage_account_id",
+					"fromPath": [
+						"line_item_usage_account_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_usage_account_name",
+					"fromPath": [
+						"line_item_usage_account_name"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_usage_amount",
+					"fromPath": [
+						"line_item_usage_amount"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_usage_end_date",
+					"fromPath": [
+						"line_item_usage_end_date"
+					],
+					"toType": "timestamp",
+					"fromType": "timestamp",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_usage_start_date",
+					"fromPath": [
+						"line_item_usage_start_date"
+					],
+					"toType": "timestamp",
+					"fromType": "timestamp",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "line_item_usage_type",
+					"fromPath": [
+						"line_item_usage_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_currency",
+					"fromPath": [
+						"pricing_currency"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_lease_contract_length",
+					"fromPath": [
+						"pricing_lease_contract_length"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_offering_class",
+					"fromPath": [
+						"pricing_offering_class"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_public_on_demand_cost",
+					"fromPath": [
+						"pricing_public_on_demand_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_public_on_demand_rate",
+					"fromPath": [
+						"pricing_public_on_demand_rate"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_purchase_option",
+					"fromPath": [
+						"pricing_purchase_option"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_rate_code",
+					"fromPath": [
+						"pricing_rate_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_rate_id",
+					"fromPath": [
+						"pricing_rate_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_term",
+					"fromPath": [
+						"pricing_term"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "pricing_unit",
+					"fromPath": [
+						"pricing_unit"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product",
+					"fromPath": [
+						"product"
+					],
+					"toType": "object",
+					"fromType": "object",
+					"dropped": true,
+					"children": [
+						{
+							"toKey": "string",
+							"fromPath": [
+								"product",
+								"string"
+							],
+							"toType": "string",
+							"fromType": "string",
+							"dropped": true,
+							"children": null
+						}
+					]
+				},
+				{
+					"toKey": "product_comment",
+					"fromPath": [
+						"product_comment"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_fee_code",
+					"fromPath": [
+						"product_fee_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_fee_description",
+					"fromPath": [
+						"product_fee_description"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_from_location",
+					"fromPath": [
+						"product_from_location"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_from_location_type",
+					"fromPath": [
+						"product_from_location_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_from_region_code",
+					"fromPath": [
+						"product_from_region_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_instance_family",
+					"fromPath": [
+						"product_instance_family"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_instance_type",
+					"fromPath": [
+						"product_instance_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_instancesku",
+					"fromPath": [
+						"product_instancesku"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_location",
+					"fromPath": [
+						"product_location"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_location_type",
+					"fromPath": [
+						"product_location_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_operation",
+					"fromPath": [
+						"product_operation"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_pricing_unit",
+					"fromPath": [
+						"product_pricing_unit"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_product_family",
+					"fromPath": [
+						"product_product_family"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_region_code",
+					"fromPath": [
+						"product_region_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_servicecode",
+					"fromPath": [
+						"product_servicecode"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_sku",
+					"fromPath": [
+						"product_sku"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_to_location",
+					"fromPath": [
+						"product_to_location"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_to_location_type",
+					"fromPath": [
+						"product_to_location_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_to_region_code",
+					"fromPath": [
+						"product_to_region_code"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "product_usagetype",
+					"fromPath": [
+						"product_usagetype"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_amortized_upfront_cost_for_usage",
+					"fromPath": [
+						"reservation_amortized_upfront_cost_for_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_amortized_upfront_fee_for_billing_period",
+					"fromPath": [
+						"reservation_amortized_upfront_fee_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_availability_zone",
+					"fromPath": [
+						"reservation_availability_zone"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_effective_cost",
+					"fromPath": [
+						"reservation_effective_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_end_time",
+					"fromPath": [
+						"reservation_end_time"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_modification_status",
+					"fromPath": [
+						"reservation_modification_status"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_amortized_upfront_cost_for_usage",
+					"fromPath": [
+						"reservation_net_amortized_upfront_cost_for_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_amortized_upfront_fee_for_billing_period",
+					"fromPath": [
+						"reservation_net_amortized_upfront_fee_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_effective_cost",
+					"fromPath": [
+						"reservation_net_effective_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_recurring_fee_for_usage",
+					"fromPath": [
+						"reservation_net_recurring_fee_for_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_unused_amortized_upfront_fee_for_billing_period",
+					"fromPath": [
+						"reservation_net_unused_amortized_upfront_fee_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_unused_recurring_fee",
+					"fromPath": [
+						"reservation_net_unused_recurring_fee"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_net_upfront_value",
+					"fromPath": [
+						"reservation_net_upfront_value"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_normalized_units_per_reservation",
+					"fromPath": [
+						"reservation_normalized_units_per_reservation"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_number_of_reservations",
+					"fromPath": [
+						"reservation_number_of_reservations"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_recurring_fee_for_usage",
+					"fromPath": [
+						"reservation_recurring_fee_for_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_reservation_a_r_n",
+					"fromPath": [
+						"reservation_reservation_a_r_n"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_start_time",
+					"fromPath": [
+						"reservation_start_time"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_subscription_id",
+					"fromPath": [
+						"reservation_subscription_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_total_reserved_normalized_units",
+					"fromPath": [
+						"reservation_total_reserved_normalized_units"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_total_reserved_units",
+					"fromPath": [
+						"reservation_total_reserved_units"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_units_per_reservation",
+					"fromPath": [
+						"reservation_units_per_reservation"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_unused_amortized_upfront_fee_for_billing_period",
+					"fromPath": [
+						"reservation_unused_amortized_upfront_fee_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_unused_normalized_unit_quantity",
+					"fromPath": [
+						"reservation_unused_normalized_unit_quantity"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_unused_quantity",
+					"fromPath": [
+						"reservation_unused_quantity"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_unused_recurring_fee",
+					"fromPath": [
+						"reservation_unused_recurring_fee"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "reservation_upfront_value",
+					"fromPath": [
+						"reservation_upfront_value"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "resource_tags",
+					"fromPath": [
+						"resource_tags"
+					],
+					"toType": "object",
+					"fromType": "object",
+					"dropped": true,
+					"children": [
+						{
+							"toKey": "string",
+							"fromPath": [
+								"resource_tags",
+								"string"
+							],
+							"toType": "string",
+							"fromType": "string",
+							"dropped": true,
+							"children": null
+						}
+					]
+				},
+				{
+					"toKey": "savings_plan_amortized_upfront_commitment_for_billing_period",
+					"fromPath": [
+						"savings_plan_amortized_upfront_commitment_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_end_time",
+					"fromPath": [
+						"savings_plan_end_time"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_instance_type_family",
+					"fromPath": [
+						"savings_plan_instance_type_family"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_net_amortized_upfront_commitment_for_billing_period",
+					"fromPath": [
+						"savings_plan_net_amortized_upfront_commitment_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_net_recurring_commitment_for_billing_period",
+					"fromPath": [
+						"savings_plan_net_recurring_commitment_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_net_savings_plan_effective_cost",
+					"fromPath": [
+						"savings_plan_net_savings_plan_effective_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_offering_type",
+					"fromPath": [
+						"savings_plan_offering_type"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_payment_option",
+					"fromPath": [
+						"savings_plan_payment_option"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_purchase_term",
+					"fromPath": [
+						"savings_plan_purchase_term"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_recurring_commitment_for_billing_period",
+					"fromPath": [
+						"savings_plan_recurring_commitment_for_billing_period"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_region",
+					"fromPath": [
+						"savings_plan_region"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_savings_plan_a_r_n",
+					"fromPath": [
+						"savings_plan_savings_plan_a_r_n"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_savings_plan_effective_cost",
+					"fromPath": [
+						"savings_plan_savings_plan_effective_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_savings_plan_rate",
+					"fromPath": [
+						"savings_plan_savings_plan_rate"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_start_time",
+					"fromPath": [
+						"savings_plan_start_time"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_total_commitment_to_date",
+					"fromPath": [
+						"savings_plan_total_commitment_to_date"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "savings_plan_used_commitment",
+					"fromPath": [
+						"savings_plan_used_commitment"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_actual_usage",
+					"fromPath": [
+						"split_line_item_actual_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_net_split_cost",
+					"fromPath": [
+						"split_line_item_net_split_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_net_unused_cost",
+					"fromPath": [
+						"split_line_item_net_unused_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_parent_resource_id",
+					"fromPath": [
+						"split_line_item_parent_resource_id"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_public_on_demand_split_cost",
+					"fromPath": [
+						"split_line_item_public_on_demand_split_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_public_on_demand_unused_cost",
+					"fromPath": [
+						"split_line_item_public_on_demand_unused_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_reserved_usage",
+					"fromPath": [
+						"split_line_item_reserved_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_split_cost",
+					"fromPath": [
+						"split_line_item_split_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_split_usage",
+					"fromPath": [
+						"split_line_item_split_usage"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_split_usage_ratio",
+					"fromPath": [
+						"split_line_item_split_usage_ratio"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "split_line_item_unused_cost",
+					"fromPath": [
+						"split_line_item_unused_cost"
+					],
+					"toType": "double",
+					"fromType": "double",
+					"dropped": false,
+					"children": null
+				},
+				{
+					"toKey": "billing_period",
+					"fromPath": [
+						"billing_period"
+					],
+					"toType": "string",
+					"fromType": "string",
+					"dropped": false,
+					"children": null
+				}
+			],
+			"parentsValid": true,
+			"calculatedType": "",
+			"codeGenVersion": 2
+		},
+		"node-1731523763363": {
+			"nodeId": "node-1731523763363",
+			"dataPreview": false,
+			"previewAmount": 0,
+			"inputs": [],
+			"name": "Account Tags",
+			"generatedNodeName": "AccountTags_node1731523763363",
+			"classification": "DataSource",
+			"type": "Catalog",
+			"isCatalog": true,
+			"database": "operations_aws_production",
+			"table": "account_tags_organization",
+			"calculatedType": "",
+			"runtimeParameters": [],
+			"codeGenVersion": 2
+		},
+		"node-1731429129432": {
+			"nodeId": "node-1731429129432",
+			"dataPreview": false,
+			"previewAmount": 0,
+			"inputs": [
+				"node-1731429060956"
+			],
+			"name": "Transformed",
+			"generatedNodeName": "Transformed_node1731429129432",
+			"classification": "DataSink",
+			"type": "S3",
+			"streamingBatchInterval": 100,
+			"format": "glueparquet",
+			"compression": "snappy",
+			"path": "s3://cds-data-lake-transformed-production/operations/aws/cost-usage-report/",
+			"partitionKeys": [],
+			"schemaChangePolicy": {
+				"enableUpdateCatalog": true,
+				"updateBehavior": "UPDATE_IN_DATABASE",
+				"database": "operations_aws_production",
+				"table": "cost_usage_report_by_account"
+			},
+			"updateCatalogOptions": "schemaAndPartitions",
+			"autoDataQuality": {
+				"isEnabled": false,
+				"evaluationContext": null
+			},
+			"calculatedType": "",
+			"codeGenVersion": 2
+		}
+	},
+	"hasBeenSaved": false,
+	"usageProfileName": null
+}


### PR DESCRIPTION
# Summary
Add an export of the Cost and Usage Glue visual ETL job definition.  There is currently no way to manage visual ETL jobs using Terraform, but this will give us a backup of the job definition in case we need to revert a change.

A future PR will have a nightly sync job that checks for new or modified visual ETL jobs and creates automated PRs with the changes.

⚠️ Note that this PR also renames the existing Glue crawlers so they have a consistent naming convention.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610