### PR TITLE
feat: grant cross-account access to Superset

### DIFF
--- a/terragrunt/aws/buckets/athena.tf
+++ b/terragrunt/aws/buckets/athena.tf
@@ -20,3 +20,32 @@ module "athena_bucket" {
     enabled = true
   }
 }
+
+resource "aws_s3_bucket_policy" "athena_bucket" {
+  bucket = module.athena_bucket.s3_bucket_id
+  policy = data.aws_iam_policy_document.athena_bucket.json
+}
+
+data "aws_iam_policy_document" "athena_bucket" {
+  statement {
+    sid    = "SupersetReadWrite"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.superset_iam_role_arn
+      ]
+    }
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject"
+    ]
+    resources = [
+      module.athena_bucket.s3_bucket_arn,
+      "${module.athena_bucket.s3_bucket_arn}/*"
+    ]
+  }
+}

--- a/terragrunt/aws/buckets/curated.tf
+++ b/terragrunt/aws/buckets/curated.tf
@@ -19,3 +19,30 @@ module "curated_bucket" {
     enabled = true
   }
 }
+
+resource "aws_s3_bucket_policy" "curated_bucket" {
+  bucket = module.curated_bucket.s3_bucket_id
+  policy = data.aws_iam_policy_document.curated_bucket.json
+}
+
+data "aws_iam_policy_document" "curated_bucket" {
+  statement {
+    sid    = "SupersetRead"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.superset_iam_role_arn
+      ]
+    }
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.curated_bucket.s3_bucket_arn,
+      "${module.curated_bucket.s3_bucket_arn}/*"
+    ]
+  }
+}

--- a/terragrunt/aws/buckets/transformed.tf
+++ b/terragrunt/aws/buckets/transformed.tf
@@ -19,3 +19,30 @@ module "transformed_bucket" {
     enabled = true
   }
 }
+
+resource "aws_s3_bucket_policy" "transformed_bucket" {
+  bucket = module.transformed_bucket.s3_bucket_id
+  policy = data.aws_iam_policy_document.transformed_bucket.json
+}
+
+data "aws_iam_policy_document" "transformed_bucket" {
+  statement {
+    sid    = "SupersetRead"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.superset_iam_role_arn
+      ]
+    }
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.transformed_bucket.s3_bucket_arn,
+      "${module.transformed_bucket.s3_bucket_arn}/*"
+    ]
+  }
+}

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -1,4 +1,35 @@
 #
+# Resource policy for the Glue Data Catalog
+#
+resource "aws_glue_resource_policy" "cross_account_access" {
+  policy = data.aws_iam_policy_document.cross_account_access.json
+}
+
+data "aws_iam_policy_document" "cross_account_access" {
+  statement {
+    sid = "SupersetReadAccess"
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.superset_iam_role_arn
+      ]
+    }
+    actions = [
+      "glue:BatchGetPartition",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetTableVersion",
+      "glue:GetTableVersions"
+    ]
+    resources = ["arn:aws:glue:${var.region}:${var.account_id}:*"]
+  }
+}
+
+#
 # Glue crawler role
 #
 resource "aws_iam_role" "glue_crawler" {

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -17,3 +17,8 @@ variable "region" {
   description = "(Required) The region to build infra in"
   type        = string
 }
+
+variable "superset_iam_role_arn" {
+  description = "(Required) The ARN of the IAM role that Superset uses to access the Glue catalog"
+  type        = string
+}

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -3,10 +3,11 @@ locals {
 }
 
 inputs = {
-  account_id        = "${local.vars.inputs.account_id}"
-  billing_tag_value = "${local.vars.inputs.billing_tag_value}"
-  env               = "${local.vars.inputs.env}"
-  region            = "ca-central-1"
+  account_id            = "${local.vars.inputs.account_id}"
+  billing_tag_value     = "${local.vars.inputs.billing_tag_value}"
+  env                   = "${local.vars.inputs.env}"
+  region                = "ca-central-1"
+  superset_iam_role_arn = "arn:aws:iam::066023111852:role/SupersetAthenaRead"
 }
 
 remote_state {


### PR DESCRIPTION
# Summary
Add S3 bucket policies and a Glue data catalog policy that allow Superset to access the data lake's transformed and curated data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610