### PR TITLE
fix: create dedicated Raw and Transformed Glue databases

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -24,7 +24,7 @@ resource "aws_glue_security_configuration" "encryption_at_rest" {
 resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
   name          = "Operations / AWS / Cost and Usage Report"
   description   = "Classify the AWS Organization Cost and Usage Report data"
-  database_name = aws_glue_catalog_database.operations_aws_production.name
+  database_name = aws_glue_catalog_database.operations_aws_production_raw.name
   table_prefix  = "cost_usage_report_"
 
   role                   = aws_iam_role.glue_crawler.arn
@@ -54,7 +54,7 @@ resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
 resource "aws_glue_crawler" "operations_aws_production_account_tags" {
   name          = "Operations / AWS / Organization / Account Tags"
   description   = "Classify the AWS Organization account tag extract"
-  database_name = aws_glue_catalog_database.operations_aws_production.name
+  database_name = aws_glue_catalog_database.operations_aws_production_raw.name
   table_prefix  = "account_tags_"
   classifiers   = [aws_glue_classifier.json_object_array.name]
 

--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -1,4 +1,9 @@
 resource "aws_glue_catalog_database" "operations_aws_production" {
   name        = "operations_aws_production"
-  description = "Data source path: /operations/aws/*"
+  description = "TRANSFORMED: data source path: /operations/aws/*"
+}
+
+resource "aws_glue_catalog_database" "operations_aws_production_raw" {
+  name        = "operations_aws_production_raw"
+  description = "RAW: data source path: /operations/aws/*"
 }


### PR DESCRIPTION
# Summary
Split the Glue databases so that Raw and Transformed data is not co-located.

This will allow us to more easily tighten the data access permissions in Superset and prevent users from seeing database tables they do not have permission to query.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610
