### PR TITLE
fix: update Superset access to Glue catalog

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -25,7 +25,11 @@ data "aws_iam_policy_document" "cross_account_access" {
       "glue:GetTableVersion",
       "glue:GetTableVersions"
     ]
-    resources = ["arn:aws:glue:${var.region}:${var.account_id}:*"]
+    resources = [
+      "arn:aws:glue:${var.region}:${var.account_id}:catalog",
+      "arn:aws:glue:${var.region}:${var.account_id}:database/${aws_glue_catalog_database.operations_aws_production.name}",
+      "arn:aws:glue:${var.region}:${var.account_id}:table/${aws_glue_catalog_database.operations_aws_production.name}/*"
+    ]
   }
 }
 


### PR DESCRIPTION
# Summary
Update the data catalog's resource policy to limit Superset to only accessing specific databases and tables.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610