### PR TITLE
feat: glue job sync workflow

### DIFF
--- a/.github/workflows/glue_job_sync.yml
+++ b/.github/workflows/glue_job_sync.yml
@@ -1,0 +1,32 @@
+name: "Glue Job Sync"
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ca-central-1
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  glue-job-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::739275439843:role/data-lake-apply
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Refresh Glue jobss
+        run: ./.github/workflows/scripts/get-glue-jobs.sh
+
+      - name: Create PR if changes
+        run: ./.github/workflows/scripts/sync-glue-jobs.sh

--- a/.github/workflows/scripts/get-glue-jobs.sh
+++ b/.github/workflows/scripts/get-glue-jobs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# Retrieves all the AWS glue jobs and creates a directory structure
+# based on the job name. The job details are saved in a JSON file.
+#
+# It is expected that the job name will be in the following format:
+# Business Unit / Product / Environment / Job Name
+#
+
+aws glue get-jobs --query 'Jobs[].Name' --output text |
+while IFS= read -r name; do
+  # Split the name on '/'
+  IFS='/' read -ra segments <<< "$name"
+
+  # Initialize directory path
+  dir_path=""
+  filename=""
+
+  # Get the number of segments
+  num_segments=${#segments[@]}
+
+  # Process all segments except the last one to build the directory path
+  for ((i=0; i<num_segments; i++)); do
+    segment="${segments[i]}"
+    segment=$(echo "$segment" | xargs)
+    segment=$(echo "$segment" | sed 's/ /-/g' | tr '[:upper:]' '[:lower:]')
+
+    if [ $i -eq $((num_segments-1)) ]; then
+      filename="$segment.json"
+    else
+      dir_path="$dir_path/$segment"
+    fi
+  done
+
+  dir_path="./terragrunt/aws/glue/etl/${dir_path}"
+
+  mkdir -p "$dir_path"
+  aws glue get-job --job-name "$name" --output json > "$dir_path/$filename"
+
+  echo "Created file: $dir_path/$filename"
+done

--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# Syncs the AWS Glue ETL jobs with the repository and creates a PR.
+#
+
+REMOTE_REPO="origin"
+BRANCH_NAME="chore/glue-job-sync"
+BASE_BRANCH="main"
+PR_TITLE="chore: automated glue job sync"
+PR_BODY="## Summary
+Automated sync of AWS Glue ETL jobs."
+
+# Check for changes in the repository
+if git diff-index --quiet HEAD --; then
+    echo "No changes detected."
+    exit 0
+else
+    echo "Changes detected."
+fi
+
+# Check if the remote branch exists
+git fetch "$REMOTE_REPO"
+if git ls-remote --heads "$REMOTE_REPO" "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+    echo "Branch '$BRANCH_NAME' exists. Checking out and updating."
+    git checkout "$BRANCH_NAME"
+else
+    echo "Branch '$BRANCH_NAME' does not exist. Creating new branch."
+    git checkout -b "$BRANCH_NAME" "$BASE_BRANCH"
+fi
+
+# Add changes and commit
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git add .
+git commit -m "$PR_TITLE"
+
+# Push branch and create the PR
+git push "$REMOTE_REPO" "$BRANCH_NAME"
+gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"


### PR DESCRIPTION
# Summary
Add a GitHub workflow that retrieves the AWS Glue jobs and checks if there are any new or changed jobs.  If there are, a PR is opened with the changes.

Once this is tested and working, it will be set to run on a schedule so that we have a backup of the visual Glue jobs, which currently cannot be managed using Terraform.

# Related
- https://github.com/cds-snc/platform-core-services/issues/622