### PR TITLE
chore: reduce account crawler frequency

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -76,7 +76,7 @@ resource "aws_glue_crawler" "operations_aws_production_account_tags" {
       Version              = 1
   })
 
-  schedule = "cron(00 13 * * ? *)" # Pickup new accounts each day
+  schedule = "cron(00 7 1 * ? *)" # Check for schema changes each month
 }
 
 # JSON classifier for arrays of objects


### PR DESCRIPTION
# Summary
The account data source crawler only needs to run monthly as the data schema is fairly static.