### PR TITLE
fix: Glue Job failure alarm

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -31,6 +31,26 @@ resource "aws_cloudwatch_metric_alarm" "glue_crawler_error" {
   ok_actions    = [aws_sns_topic.cloudwatch_ok_action.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "glue_job_failures" {
+  alarm_name          = "glue-job-failures"
+  alarm_description   = "Glue Job state has changed to `FAILURE`, `TIMEOUT` or `ERROR`."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Invocations"
+  namespace           = "AWS/Events"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alarm_action.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_ok_action.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.glue_job_failure.name
+  }
+}
+
 #
 # Log Insight queries
 #

--- a/terragrunt/aws/alarms/eventbridge.tf
+++ b/terragrunt/aws/alarms/eventbridge.tf
@@ -11,31 +11,3 @@ resource "aws_cloudwatch_event_rule" "glue_job_failure" {
   })
 }
 
-#
-# Publish Glue Job failures to SNS using a CloudWatch Alarm message payload.
-# This allows us to use the existing SRE Bot webhooks to post to Slack.
-#
-resource "aws_cloudwatch_event_target" "glue_job_failure" {
-  rule      = aws_cloudwatch_event_rule.glue_job_failure.name
-  target_id = "send-to-sns"
-  arn       = aws_sns_topic.cloudwatch_alarm_action.arn
-
-  input_transformer {
-    input_paths = {
-      jobName = "$.detail.jobName"
-      state   = "$.detail.state"
-      message = "$.detail.message"
-    }
-    input_template = jsonencode({
-      Message = jsonencode({
-        AlarmArn         = "arn:aws:cloudwatch:${var.region}:${var.account_id}:alarm:glue-job-failure",
-        AlarmName        = "glue-job-failure",
-        AlarmDescription = "`<state>` detected for Glue job `<jobName>`",
-        AWSAccountId     = var.account_id,
-        OldStateValue    = "OK",
-        NewStateValue    = "ALARM",
-        NewStateReason   = "<message>",
-      })
-    })
-  }
-}


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm that triggers when the EventBridge rule monitoring for failed Glue jobs is invoked.
