### PR TITLE
fix: Glue job failure trigger on MatchedEvents

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "glue_job_failures" {
   alarm_description   = "Glue Job state has changed to `FAILURE`, `TIMEOUT` or `ERROR`."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = "Invocations"
+  metric_name         = "MatchedEvents"
   namespace           = "AWS/Events"
   period              = "60"
   statistic           = "Sum"


### PR DESCRIPTION
# Summary
Update the Glue job failure alarm to trigger when an event has been matched. Now that the rule target has been removed, there are no longer `Invocation` metrics reported.