### PR TITLE
fix: glue job sync for multiple jobs

### DIFF
--- a/.github/workflows/scripts/get-glue-jobs.sh
+++ b/.github/workflows/scripts/get-glue-jobs.sh
@@ -9,8 +9,10 @@ set -euo pipefail
 # Business Unit / Product / Environment / Job Name
 #
 
-aws glue get-jobs --query 'Jobs[].Name' --output text |
+# shellcheck disable=SC2016
+aws glue get-jobs --query 'join(`\n`, Jobs[].Name)' --output text |
 while IFS= read -r name; do
+  echo "Syncing job: $name"
   # Split the name on '/'
   IFS='/' read -ra segments <<< "$name"
 


### PR DESCRIPTION
# Summary
Update the Glue job sync script so that it can handle processing multiple Glue jobs returned by AWS.
