### PR TITLE
docs: add data catalog and data pipeline readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Data Lake
 This repository holds the Terraform and AWS Glue jobs that manage the Platform Data Lake.
+
+You can read more about the datasets below:
+
+- [Data catalog](./docs/data/catalog)
+- [Data pipelines](./docs/data/pipelines/)

--- a/docs/data/catalog/README.md
+++ b/docs/data/catalog/README.md
@@ -1,0 +1,4 @@
+# Data catalog
+Provides an inventory that contains metadata, descriptions, and technical details about all data sources within the data lake.
+
+:page_facing_up: When adding a new pipeline, please use [template.md](./template.md) as a starting point.

--- a/docs/data/catalog/template.md
+++ b/docs/data/catalog/template.md
@@ -1,0 +1,47 @@
+# Dataset name
+
+A straightforward one or two sentence line explaining what the dataset it. Dataset is one word.
+
+An additional line that describes what each row in the table represents.
+
+If a data pipeline doc exists for this dataset, provide a link to it as well.
+
+## Provenance
+
+Briefly describe where the dataset comes from using words. If from a database, indicate the table or view it is derived from, as well as any critical transformations or filters applied. If the dataset is sourced from a public distribution, link the repo or website where the dataset can be found. If the dataset is collected based on an experiment or survey, link the protocol where analysts can find more details.
+
+* **Updated:** Frequency of update, if automated. If manual, indicate "Manually"
+* **Last Updated:** (if manual) Date/time of last time dataset was update
+* **Owner:** Who is responsible for the data. This can be a person or an organization.
+* **Contact:** Email address or Slack handle of where queries should be directed
+* **Location:** (optional) Path to S3 bucket
+
+## Fields
+
+[Link to the first 10-20 rows of the table as CSV](http://www.example.com/link). If the head of the table is not representative (e.g., missing data) or sensitive (contains PII), more appropriate rows may be selected instead.
+
+A bulleted list of field names should be included, alongside a brief description of the field. Boolean descriptions can simply be the question answered by the boolean. The data type of a field and the unit of measurement should be included as well. The names of data types are dictated by the storage format. For example, the Parquet storage format commonly includes include booleans, dates, floats, integers, strings, times, and timestamps. There is no need to include the integer or float width unless the circumstances are exceptional. 
+
+Sometimes the name of the field is already very descriptive of what the field represents! It's ok if the description adds little value.
+
+For string columns with only a few options (i.e., factors), include what the possible options are.
+
+A few field examples:
+
+* **id** (string) - version 4 UUID that identifies the user
+* **registration_date** (datetime) - when the user registered, in UTC
+* **age** (integer) - user's age at registration, in years
+* **first_name** (string) - user's first or given name
+* **user_hometown** (string) - user's home town
+* **height** (float) - user's height in centimeters, converted from feet/inches depending on user's localization settings
+* **pizza_opinion** (string) - how much the user indicated they like pizza, one of "Delicious", "It's Alright" or "Hate It". May be missing if user registered before June 20, 2022.
+* **first_time_login** (boolean) - has the user logged into their account after completing registration?
+
+
+## Notes (optional)
+
+Additional details that are relevant to the data set. For example:
+
+"Beginning June 20, 2022, we started asking users how much they liked pizza, and preventing them from logging in if they indicated they hated it".
+
+"We stopped updating this dataset in April 2024 after trying a poutine for the first time and deciding that there was no future for our pizza-based website."

--- a/docs/data/pipelines/README.md
+++ b/docs/data/pipelines/README.md
@@ -1,0 +1,6 @@
+# Data pipelines
+Provides details on the automated processes that import and transform the data sources that are part of the data lake.
+
+- [Operations / AWS / Cost and Usage Report](./operations/aws/cost-and-usage-report.md)
+
+:page_facing_up: When adding a new pipeline, please use [template.md](./template.md) as a starting point.

--- a/docs/data/pipelines/template.md
+++ b/docs/data/pipelines/template.md
@@ -1,0 +1,62 @@
+# Dataset name
+
+## Description
+
+A simple description of the dataset explaining what it is. 
+
+If a data catalog doc exists for the pipeline, provide a link to it as well.
+
+## Data pipeline
+
+If possible, provide a high level flow diagram show how the data moves from source system(s) to the data lake.
+
+```mermaid
+graph TD
+    %% Source Systems
+    Source1[Data source name]
+    Source2[Data source name]
+    
+    %% Storage
+    RawS3["`**S3 Bucket (Raw)**<br/>cds-data-lake-raw-production`"]
+    TransS3["`**S3 Bucket (Transformed)**<br/>cds-data-lake-transformed-production`"]
+    
+    %% Processing
+    Crawlers["Crawlers (frequency)"]
+    CatalogRaw["`**Data Catalog (Raw)**<br/>database_name`"]
+    CatalogTransformed["`**Data Catalog (Transformed)**<br/>database_name`"]
+    ETL["ETL Job (frequency)"]
+
+    %% Flow
+    subgraph org[Source system name]
+        Source1
+        Source2
+    end
+
+    Source1 --> |Transfer process|RawS3
+    Source2 --> |Transfer process|RawS3
+
+    subgraph datalake[Data Lake account]
+        RawS3 --> Crawlers
+        Crawlers --> |Updates Schema|CatalogRaw
+        CatalogRaw --> ETL
+        ETL --> TransS3
+        ETL --> CatalogTransformed
+    end
+```
+
+### Source data
+
+A description of the source data, its origin(s) and owners.
+
+### Crawlers (optional)
+
+Details on how the data's schema is automatically determined.  For some data sources, this will not be required as the data schema will be defined manually.
+
+### Extract, Transform and Load (ETL) Jobs
+
+Provide a description on the ETL jobs, including their:
+
+- source datasets;
+- transform steps;
+- target datasets; and
+- run frequency.


### PR DESCRIPTION
# Summary
Add READMEs and templates for the data catalog and data pipeline documentation.

The new folder structure can be seen by browsing this PRs branch:
https://github.com/cds-snc/data-lake/tree/docs/data-catalog-structure/docs/data

# Related
- https://github.com/cds-snc/platform-core-services/issues/627
- https://github.com/cds-snc/ADR/pull/35