### PR TITLE
docs: provide links to AWS CUR data catalog

### DIFF
--- a/docs/data/catalog/README.md
+++ b/docs/data/catalog/README.md
@@ -1,4 +1,6 @@
 # Data catalog
 Provides an inventory that contains metadata, descriptions, and technical details about all data sources within the data lake.
 
+- [Operations / AWS / Cost and Usage Report](./operations/aws/cost-and-usage-report.md)
+
 :page_facing_up: When adding a new pipeline, please use [template.md](./template.md) as a starting point.

--- a/docs/data/catalog/operations/aws/cost-and-usage-report.md
+++ b/docs/data/catalog/operations/aws/cost-and-usage-report.md
@@ -6,6 +6,8 @@ Each row describes the cost of using a particular AWS service (i.e., a line item
 
 This dataset is represented in [Superset](https://superset.cdssandbox.xyz/) as the Physical dataset [`cost_usage_report_by_account`](https://superset.cdssandbox.xyz/explore/?datasource_type=table&datasource_id=68). All of the Virtual datasets in the "Operations / AWS / Cost and Usage" group are derived from it.
 
+:information_source: [Data Pipeline](../../../pipelines/operations/aws/cost-and-usage-report.md)
+
 **Keywords:** AWS, Amazon, cost, usage, fees
 
 ## Provenance

--- a/docs/data/catalog/operations/aws/cost-and-usage-report.md
+++ b/docs/data/catalog/operations/aws/cost-and-usage-report.md
@@ -6,7 +6,7 @@ Each row describes the cost of using a particular AWS service (i.e., a line item
 
 This dataset is represented in [Superset](https://superset.cdssandbox.xyz/) as the Physical dataset [`cost_usage_report_by_account`](https://superset.cdssandbox.xyz/explore/?datasource_type=table&datasource_id=68). All of the Virtual datasets in the "Operations / AWS / Cost and Usage" group are derived from it.
 
-:information_source: [Data Pipeline](../../../pipelines/operations/aws/cost-and-usage-report.md)
+[:information_source:  View the data pipeline](../../../pipelines/operations/aws/cost-and-usage-report.md)
 
 **Keywords:** AWS, Amazon, cost, usage, fees
 

--- a/docs/data/catalog/operations/aws/cost-and-usage-report.md
+++ b/docs/data/catalog/operations/aws/cost-and-usage-report.md
@@ -1,4 +1,4 @@
-# AWS Cost and Usage Report
+# Operations / AWS / Cost and Usage Report
 
 Dataset describing how much was spent on Amazon Web Services (AWS) by CDS.
 
@@ -6,9 +6,11 @@ Each row describes the cost of using a particular AWS service (i.e., a line item
 
 This dataset is represented in [Superset](https://superset.cdssandbox.xyz/) as the Physical dataset [`cost_usage_report_by_account`](https://superset.cdssandbox.xyz/explore/?datasource_type=table&datasource_id=68). All of the Virtual datasets in the "Operations / AWS / Cost and Usage" group are derived from it.
 
-[:information_source:  View the data pipeline](../../../pipelines/operations/aws/cost-and-usage-report.md)
-
 **Keywords:** AWS, Amazon, cost, usage, fees
+
+---
+
+[:information_source:  View the data pipeline](../../../pipelines/operations/aws/cost-and-usage-report.md)
 
 ## Provenance
 

--- a/docs/data/pipelines/operations/aws/cost-and-usage-report.md
+++ b/docs/data/pipelines/operations/aws/cost-and-usage-report.md
@@ -12,6 +12,8 @@ FROM
 LIMIT 10;
 ```
 
+:information_source: [Data Catalog](../../../catalog/operations/aws/cost-and-usage-report.md)
+
 ## Data pipeline
 A high level view is shown below with more details about each step following the diagram.
 

--- a/docs/data/pipelines/operations/aws/cost-and-usage-report.md
+++ b/docs/data/pipelines/operations/aws/cost-and-usage-report.md
@@ -12,6 +12,8 @@ FROM
 LIMIT 10;
 ```
 
+---
+
 [:information_source:  View the data catalog](../../../catalog/operations/aws/cost-and-usage-report.md)
 
 ## Data pipeline

--- a/docs/data/pipelines/operations/aws/cost-and-usage-report.md
+++ b/docs/data/pipelines/operations/aws/cost-and-usage-report.md
@@ -12,7 +12,7 @@ FROM
 LIMIT 10;
 ```
 
-:information_source: [Data Catalog](../../../catalog/operations/aws/cost-and-usage-report.md)
+[:information_source:  View the data catalog](../../../catalog/operations/aws/cost-and-usage-report.md)
 
 ## Data pipeline
 A high level view is shown below with more details about each step following the diagram.


### PR DESCRIPTION
# Summary
Update various documents with links to the AWS CUR data catalog and data pipeline.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/627