### PR TITLE
fix: run CUR crawler for first 10 days of month

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -45,7 +45,7 @@ resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
       Version              = 1
   })
 
-  schedule = "cron(00 7 1 * ? *)" # Create the new month's partition key
+  schedule = "cron(00 7 1-10 * ? *)" # Run for the first 10 days of each month to create the new partition key
 }
 
 #


### PR DESCRIPTION
# Summary
Update the Cost and Usage Report crawler to run every day for the first 10 days of the month.  This is being done since the new month's partition key is not always added on the first day of the month.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/633