### PR TITLE
feat: switch to Terraform lock file

### DIFF
--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -22,7 +22,7 @@ remote_state {
   config = {
     encrypt        = true
     bucket         = "cds-data-lake-tfstate-${local.vars.inputs.env}"
-    dynamodb_table = "terraform-state-lock-dynamo"
+    use_lockfile   = true
     region         = "ca-central-1"
     key            = "${path_relative_to_include()}/terraform.tfstate"
   }

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -21,7 +21,7 @@ remote_state {
   }
   config = {
     encrypt        = true
-    bucket         = "cds-data-lake-tfstate-${local.vars.inputs.env}"
+    bucket         = "cds-data-lake-tfstate"
     use_lockfile   = true
     region         = "ca-central-1"
     key            = "${path_relative_to_include()}/terraform.tfstate"


### PR DESCRIPTION
# Summary
Switch from DynamoDB to the new `.tflock` file for state locking during TF apply operations.
