### PR TITLE
feat: add temporary GC Forms test data

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -19,6 +19,34 @@ resource "aws_glue_security_configuration" "encryption_at_rest" {
 }
 
 #
+# GC Forms: Forms
+#
+resource "aws_glue_crawler" "platform_gc_forms_forms_production" {
+  name          = "Platform / GC Forms / Forms"
+  description   = "Classify the GC Forms forms (template) data"
+  database_name = aws_glue_catalog_database.platform_gc_forms_production.name
+  table_prefix  = "forms_"
+
+  role                   = aws_iam_role.glue_crawler.arn
+  security_configuration = aws_glue_security_configuration.encryption_at_rest.name
+
+  s3_target {
+    path = "s3://${var.transformed_bucket_name}/platform/gc-forms/forms"
+  }
+
+  configuration = jsonencode(
+    {
+      CrawlerOutput = {
+        Tables = {
+          TableThreshold = 2
+        }
+      }
+      CreatePartitionIndex = true
+      Version              = 1
+  })
+}
+
+#
 # Cost and Usage Report
 #
 resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {

--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -1,3 +1,8 @@
+resource "aws_glue_catalog_database" "platform_gc_forms_production" {
+  name        = "platform_gc_forms_production"
+  description = "TRANSFORMED: data source path: /platform/gc-forms/*"
+}
+
 resource "aws_glue_catalog_database" "operations_aws_production" {
   name        = "operations_aws_production"
   description = "TRANSFORMED: data source path: /operations/aws/*"

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -26,7 +26,9 @@ data "aws_iam_policy_document" "cross_account_access" {
     resources = [
       "arn:aws:glue:${var.region}:${var.account_id}:catalog",
       "arn:aws:glue:${var.region}:${var.account_id}:database/${aws_glue_catalog_database.operations_aws_production.name}",
-      "arn:aws:glue:${var.region}:${var.account_id}:table/${aws_glue_catalog_database.operations_aws_production.name}/*"
+      "arn:aws:glue:${var.region}:${var.account_id}:table/${aws_glue_catalog_database.operations_aws_production.name}/*",
+      "arn:aws:glue:${var.region}:${var.account_id}:database/${aws_glue_catalog_database.platform_gc_forms_production.name}",
+      "arn:aws:glue:${var.region}:${var.account_id}:table/${aws_glue_catalog_database.platform_gc_forms_production.name}/*"
     ]
   }
 }


### PR DESCRIPTION
# Summary
Add a Glue database and crawler to hold the GC Forms form (template) data for testing in Staging Superset.

This dataset will be refreshed ad-hoc to help with testing.

⚠️ Changes were applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648