### PR TITLE
feat: add AWS Glue bucket to hold scripts

### DIFF
--- a/terragrunt/aws/buckets/glue.tf
+++ b/terragrunt/aws/buckets/glue.tf
@@ -1,0 +1,21 @@
+#
+# Holds ETL job scripts used by Glue
+#
+module "glue_bucket" {
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v10.2.1"
+  bucket_name       = "cds-data-lake-glue-${var.env}"
+  billing_tag_value = var.billing_tag_value
+
+  logging = {
+    target_bucket = module.log_bucket.s3_bucket_id
+    target_prefix = "glue/"
+  }
+
+  lifecycle_rule = [
+    local.lifecycle_remove_noncurrent_versions
+  ]
+
+  versioning = {
+    enabled = true
+  }
+}

--- a/terragrunt/aws/buckets/outputs.tf
+++ b/terragrunt/aws/buckets/outputs.tf
@@ -18,6 +18,16 @@ output "curated_bucket_name" {
   value       = module.curated_bucket.s3_bucket_id
 }
 
+output "glue_bucket_arn" {
+  description = "ARN of the S3 Glue data bucket."
+  value       = module.glue_bucket.s3_bucket_arn
+}
+
+output "glue_bucket_name" {
+  description = "Name of the S3 Glue data bucket."
+  value       = module.glue_bucket.s3_bucket_id
+}
+
 output "raw_bucket_arn" {
   description = "ARN of the S3 Raw data bucket."
   value       = module.raw_bucket.s3_bucket_arn


### PR DESCRIPTION
# Summary
Add an S3 bucket to hold Glue scripts that will be used to define ETL jobs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648