### PR TITLE
fix: retrieve glue jobs after branch checkout

### DIFF
--- a/.github/workflows/glue_job_sync.yml
+++ b/.github/workflows/glue_job_sync.yml
@@ -29,9 +29,6 @@ jobs:
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get Glue jobs
-        run: ./.github/workflows/scripts/get-glue-jobs.sh
-
       - name: Create PR if changes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -22,7 +22,8 @@ if git ls-remote --heads "$REMOTE_REPO" "$BRANCH_NAME" | grep -q "$BRANCH_NAME";
     CREATE_PR="false"
 else
     echo "Branch '$BRANCH_NAME' does not exist. Creating new branch."
-    git checkout -b "$BRANCH_NAME" "$BASE_BRANCH"
+    git fetch "$REMOTE_REPO" "$BASE_BRANCH"
+    git checkout -b "$BRANCH_NAME" "$REMOTE_REPO/$BASE_BRANCH"
 fi
 
 echo "Syncing Glue jobs..."

--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -17,16 +17,16 @@ Automated sync of AWS Glue ETL jobs."
 
 # Check if the remote branch exists
 if git ls-remote --heads "$REMOTE_REPO" "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-    echo "Branch '$BRANCH_NAME' exists. Checking out and updating."
-    git stash
+    echo "Branch '$BRANCH_NAME' exists. Checking out."
     git checkout "$BRANCH_NAME"
-    git stash apply --quiet || true
-    git checkout --theirs -- .
     CREATE_PR="false"
 else
     echo "Branch '$BRANCH_NAME' does not exist. Creating new branch."
     git checkout -b "$BRANCH_NAME" "$BASE_BRANCH"
 fi
+
+echo "Syncing Glue jobs..."
+.github/workflows/scripts/get-glue-jobs.sh
 
 # Check for changes in the branch
 if git diff-index --quiet HEAD -- "$JOB_DIR"; then

--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -43,7 +43,7 @@ echo "Committing changes..."
 FILES_CHANGED="$(git status --porcelain | awk '{print $2}')"
 for FILE in $FILES_CHANGED; do
     MESSAGE="chore: regenerate $(basename "$FILE") for $(date -u '+%Y-%m-%d')"
-    SHA="$(git rev-parse $BRANCH_NAME:"$FILE" || "")"
+    SHA="$(git rev-parse $BRANCH_NAME:"$FILE" || echo "")"
     gh api --method PUT /repos/cds-snc/data-lake/contents/"$FILE" \
         --field message="$MESSAGE" \
         --field content="$(base64 -w 0 "$FILE")" \


### PR DESCRIPTION
# Summary
Update the Glue job sync workflow to retrieve the latest jobs after the update branch has been checked out.