### PR TITLE
fix: separate Superset role access to Glue databases

### DIFF
--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  # To grant a Superset IAM role access to a Glue catalog database, the role ARN must end with the database name:
+  # - arn:aws:iam::123456789012:role/SupersetAthenaRead-datatabase_name
+  # The Superset role ARNs are managed by the `superset_iam_role_arns` input variable.
+  glue_catalog_databases = [
+    aws_glue_catalog_database.platform_gc_forms_production,
+    aws_glue_catalog_database.operations_aws_production,
+  ]
   glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"
   glue_etl_log_group_name     = "/aws-glue/jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"
 }

--- a/terragrunt/env/production/glue/.terraform.lock.hcl
+++ b/terragrunt/env/production/glue/.terraform.lock.hcl
@@ -36,3 +36,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ecf3a4f3c57eb7e89f71b8559e2a71e4cdf94eea0118ec4f2cb37e4f4d71a069",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:6XyefmvbkprppmYbGmMcQW5NB4w6C363SSShzuhF4R0=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -8,8 +8,9 @@ inputs = {
   env                    = "${local.vars.inputs.env}"
   region                 = "ca-central-1"
   superset_iam_role_arns = [
-    "arn:aws:iam::066023111852:role/SupersetAthenaRead",
-    "arn:aws:iam::257394494478:role/SupersetAthenaRead"
+    "arn:aws:iam::066023111852:role/SupersetAthenaRead-operations_aws_production",
+    "arn:aws:iam::257394494478:role/SupersetAthenaRead-operations_aws_production",
+    "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_gc_forms_production"
   ]
 }
 


### PR DESCRIPTION
# Summary
Update the IAM access to the Glue catalog databases so that it is split by Superset role.  This will make it easier to grant fine-grained access to a database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/649