### PR TITLE
test: 1 million forms rows

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc-forms/scripts/generate_test_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc-forms/scripts/generate_test_data.py
@@ -110,7 +110,7 @@ def generate_random_value(field):
 # ----------------------------------------------------------------------------
 # 3. Build random rows by iterating over the schema
 # ----------------------------------------------------------------------------
-NUM_ROWS = 10000
+NUM_ROWS = 1000000
 
 data_rows = []
 for _ in range(NUM_ROWS):


### PR DESCRIPTION
# Summary
Update the Forms ETL script to generate 1 million rows of test data.
