### PR TITLE
fix: Glue job sync changes detected condition

### DIFF
--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -34,7 +34,8 @@ if git diff-index --quiet HEAD -- "$JOB_DIR"; then
     echo "No changes detected."
     exit 0
 else
-    echo "Changes detected."
+    echo "Changes detected:"
+    git diff -- "$JOB_DIR"
     git push "$REMOTE_REPO" "$BRANCH_NAME"
 fi
 
@@ -42,6 +43,7 @@ fi
 echo "Committing changes..."
 FILES_CHANGED="$(git status --porcelain | awk '{print $2}')"
 for FILE in $FILES_CHANGED; do
+    echo "Committing $FILE..."
     MESSAGE="chore: regenerate $(basename "$FILE") for $(date -u '+%Y-%m-%d')"
     SHA="$(git rev-parse $BRANCH_NAME:"$FILE" || echo "")"
     gh api --method PUT /repos/cds-snc/data-lake/contents/"$FILE" \

--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -30,7 +30,7 @@ echo "Syncing Glue jobs..."
 .github/workflows/scripts/get-glue-jobs.sh
 
 # Check for changes in the branch
-if git diff-index --quiet HEAD -- "$JOB_DIR"; then
+if ! git status --porcelain "$JOB_DIR" | grep -q "."; then
     echo "No changes detected."
     exit 0
 else


### PR DESCRIPTION
# Summary
Update the Glue job sync so that it properly detects changes before attempting to commit them and open a PR.

Also add some extra logging details in case we have to further troubleshoot.