### PR TITLE
feat: grant access to the Superset read `all` IAM role

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -33,8 +33,8 @@ data "aws_iam_policy_document" "cross_account_access" {
     ]
     resources = [
       "arn:aws:glue:${var.region}:${var.account_id}:catalog",
-      "arn:aws:glue:${var.region}:${var.account_id}:database/${each.value.name}",
-      "arn:aws:glue:${var.region}:${var.account_id}:table/${each.value.name}/*",
+      "arn:aws:glue:${var.region}:${var.account_id}:database/${each.value.name == "all" ? "*" : each.value.name}",
+      "arn:aws:glue:${var.region}:${var.account_id}:table/${each.value.name == "all" ? "*" : each.value.name}/*",
     ]
   }
 }

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -12,13 +12,13 @@ data "aws_iam_policy_document" "cross_account_access_combined" {
 }
 
 data "aws_iam_policy_document" "cross_account_access" {
-  for_each = { for database in local.glue_catalog_databases : database.name => database }
+  for_each = toset(local.glue_catalog_databases)
 
   statement {
-    sid = "SupersetReadAccess${join("", [for word in split("_", replace(each.value.name, "/[^a-zA-Z0-9_]/", "")) : title(word)])}"
+    sid = "SupersetReadAccess${join("", [for word in split("_", replace(each.value, "/[^a-zA-Z0-9_]/", "")) : title(word)])}"
     principals {
       type        = "AWS"
-      identifiers = [for arn in var.superset_iam_role_arns : arn if endswith(arn, each.value.name)]
+      identifiers = [for arn in var.superset_iam_role_arns : arn if endswith(arn, each.value)]
     }
     actions = [
       "glue:BatchGetPartition",
@@ -33,8 +33,8 @@ data "aws_iam_policy_document" "cross_account_access" {
     ]
     resources = [
       "arn:aws:glue:${var.region}:${var.account_id}:catalog",
-      "arn:aws:glue:${var.region}:${var.account_id}:database/${each.value.name == "all" ? "*" : each.value.name}",
-      "arn:aws:glue:${var.region}:${var.account_id}:table/${each.value.name == "all" ? "*" : each.value.name}/*",
+      "arn:aws:glue:${var.region}:${var.account_id}:database/${each.value == "all" ? "*" : each.value}",
+      "arn:aws:glue:${var.region}:${var.account_id}:table/${each.value == "all" ? "*" : each.value}/*",
     ]
   }
 }

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -4,8 +4,8 @@ locals {
   # The Superset role ARNs are managed by the `superset_iam_role_arns` input variable.
   glue_catalog_databases = [
     "all", # special case for an IAM role with access to all databases
-    aws_glue_catalog_database.platform_gc_forms_production,
-    aws_glue_catalog_database.operations_aws_production,
+    aws_glue_catalog_database.platform_gc_forms_production.name,
+    aws_glue_catalog_database.operations_aws_production.name,
   ]
   glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"
   glue_etl_log_group_name     = "/aws-glue/jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -3,6 +3,7 @@ locals {
   # - arn:aws:iam::123456789012:role/SupersetAthenaRead-datatabase_name
   # The Superset role ARNs are managed by the `superset_iam_role_arns` input variable.
   glue_catalog_databases = [
+    "all", # special case for an IAM role with access to all databases
     aws_glue_catalog_database.platform_gc_forms_production,
     aws_glue_catalog_database.operations_aws_production,
   ]

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -8,7 +8,9 @@ inputs = {
   env                    = "${local.vars.inputs.env}"
   region                 = "ca-central-1"
   superset_iam_role_arns = [
+    "arn:aws:iam::066023111852:role/SupersetAthenaRead-all",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-operations_aws_production",
+    "arn:aws:iam::257394494478:role/SupersetAthenaRead-all",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_gc_forms_production"
   ]


### PR DESCRIPTION
# Summary
Update the IAM policies to all the new SupersetAthenaRead-all to read from all databases.  This role will be used to create virtual datasets that join across databases.

# Related
- https://github.com/cds-snc/cds-superset/pull/269