### PR TITLE
feat: add scheduled Lambda Freshdesk data export

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -19,6 +19,7 @@ env:
   TERRAGRUNT_VERSION: 0.68.6
   TF_INPUT: false
   TF_VAR_cloudwatch_alarm_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_OPS }}
+  TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
 
 permissions:
   id-token: write
@@ -55,6 +56,10 @@ jobs:
 
       - name: Terragrunt apply alarms
         working-directory: terragrunt/env/production/alarms
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply export
+        working-directory: terragrunt/env/production/export
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Report deployment to Sentinel

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -19,6 +19,7 @@ env:
   TERRAGRUNT_VERSION: 0.68.6
   TF_INPUT: false
   TF_VAR_cloudwatch_alarm_slack_webhook: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_OPS }}
+  TF_VAR_freshdesk_api_key: ${{ secrets.PRODUCTION_FRESHDESK_API_KEY }}
 
 permissions:
   id-token: write
@@ -75,5 +76,14 @@ jobs:
           directory: "terragrunt/env/production/alarms"
           comment-delete: "true"
           comment-title: "Production: alarms 🚨"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan export
+        uses: cds-snc/terraform-plan@d79bcf0eccf632a0ad9e9193072b42c970766c5b # v3.3.1
+        with:
+          directory: "terragrunt/env/production/export"
+          comment-delete: "true"
+          comment-title: "Production: export 💾"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"

--- a/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
@@ -1,0 +1,42 @@
+#
+# Freshdesk export via a scheduled Lambda function
+#
+module "platform_support_freshdesk_export" {
+  source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.2.2"
+
+  lambda_name                = "platform-support-freshdesk-export"
+  lambda_schedule_expression = "rate(1 day)"
+  s3_arn_write_path          = "${var.raw_bucket_arn}${local.freshdesk_export_path}"
+
+  lambda_policies = [
+    data.aws_iam_policy_document.platform_support_freshdesk_export.json
+  ]
+
+  lambda_environment_variables = {
+    FRESHDESK_API_KEY_PARAMETER_NAME = aws_ssm_parameter.freshdesk_api_key.name
+    FRESHDESK_DOMAIN                 = "cds-snc.freshdesk.com"
+    S3_BUCKET_NAME                   = var.raw_bucket_name
+    S3_OBJECT_PREFIX                 = local.freshdesk_export_path
+  }
+
+  billing_tag_value = var.billing_tag_value
+}
+
+data "aws_iam_policy_document" "platform_support_freshdesk_export" {
+  statement {
+    sid    = "GetSSMParameters"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter*",
+    ]
+    resources = [
+      aws_ssm_parameter.freshdesk_api_key.arn
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "freshdesk_api_key" {
+  name  = "/platform/support/freshdesk-api-key"
+  type  = "SecureString"
+  value = var.freshdesk_api_key
+}

--- a/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
@@ -6,7 +6,7 @@ module "platform_support_freshdesk_export" {
 
   lambda_name                = "platform-support-freshdesk-export"
   lambda_schedule_expression = "cron(0 5 * * ? *)" # 5am UTC every day
-  s3_arn_write_path          = "${var.raw_bucket_arn}${local.freshdesk_export_path}"
+  s3_arn_write_path          = "${var.raw_bucket_arn}/${local.freshdesk_export_path}/*"
 
   lambda_policies = [
     data.aws_iam_policy_document.platform_support_freshdesk_export.json

--- a/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
@@ -5,7 +5,7 @@ module "platform_support_freshdesk_export" {
   source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.2.2"
 
   lambda_name                = "platform-support-freshdesk-export"
-  lambda_schedule_expression = "rate(1 day)"
+  lambda_schedule_expression = "cron(0 5 * * ? *)" # 5am UTC every day
   s3_arn_write_path          = "${var.raw_bucket_arn}${local.freshdesk_export_path}"
 
   lambda_policies = [

--- a/terragrunt/aws/export/platform/support/freshdesk/locals.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  freshdesk_export_path = "/platform/support/freshdesk/"
+  freshdesk_export_path = "platform/support/freshdesk"
 }

--- a/terragrunt/aws/export/platform/support/freshdesk/locals.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  freshdesk_export_path = "/platform/support/freshdesk/"
+}

--- a/terragrunt/aws/export/platform/support/freshdesk/variables.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/variables.tf
@@ -1,0 +1,20 @@
+variable "billing_tag_value" {
+  description = "The billing tag value to apply to resources."
+  type        = string
+}
+
+variable "freshdesk_api_key" {
+  description = "The Freshdesk API key to use for data exports."
+  type        = string
+  sensitive   = true
+}
+
+variable "raw_bucket_arn" {
+  description = "The ARN of the Raw bucket."
+  type        = string
+}
+
+variable "raw_bucket_name" {
+  description = "The name of the Raw bucket."
+  type        = string
+}

--- a/terragrunt/aws/export/tasks.tf
+++ b/terragrunt/aws/export/tasks.tf
@@ -1,0 +1,8 @@
+module "platform_support_freshdesk_export" {
+  source = "./platform/support/freshdesk"
+
+  freshdesk_api_key = var.freshdesk_api_key
+  raw_bucket_arn    = var.raw_bucket_arn
+  raw_bucket_name   = var.raw_bucket_name
+  billing_tag_value = var.billing_tag_value
+}

--- a/terragrunt/aws/export/variables.tf
+++ b/terragrunt/aws/export/variables.tf
@@ -1,0 +1,15 @@
+variable "freshdesk_api_key" {
+  description = "The Freshdesk API key to use for data exports."
+  type        = string
+  sensitive   = true
+}
+
+variable "raw_bucket_arn" {
+  description = "The ARN of the Raw bucket."
+  type        = string
+}
+
+variable "raw_bucket_name" {
+  description = "The name of the Raw bucket."
+  type        = string
+}

--- a/terragrunt/env/production/export/.terraform.lock.hcl
+++ b/terragrunt/env/production/export/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.83.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:jEKbxB3GtA9ak4XXkaIXTMbnu/SDiiqNKDeF/78XrHc=",
+    "zh:0313253c78f195973752c4d1f62bfdd345a9c99c1bc7a612a8c1f1e27d51e49e",
+    "zh:108523f3e9ebc93f7d900c51681f6edbd3f3a56b8a62b0afc31d8214892f91e0",
+    "zh:175b9bf2a00bea6ac1c73796ad77b0e00dcbbde166235017c49377d7763861d8",
+    "zh:1c8bf55b8548bbad683cd6d7bdb03e8840a00b2422dc1529ffb9892820657130",
+    "zh:22338f09bae62d5ff646de00182417f992548da534fee7d98c5d0136d4bd5d7a",
+    "zh:92de1107ec43de60612be5f6255616f16a9cf82d88df1af1c0471b81f3a82c16",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c7bfb7afea330e6d90e1466125a8cba3db1ed4043c5da52f737459c89290a6e",
+    "zh:ba59b374d477e5610674b70f5abfe0408e8f809390347372751384151440d3d0",
+    "zh:bd1c433966002f586d63cb1e3e16326991f238bc6beeb2352be36ec651917b0b",
+    "zh:ca2b4d1d02651c15261fffa4b142e45def9a22c6069353f0f663fd2046e268f8",
+    "zh:d8ed98c748f7a3f1a72277cfee9afe346aca39ab319d17402277852551d8f14a",
+    "zh:ed3d8bc89de5f35f3c5f4802ff7c749fda2e2be267f9af4a850694f099960a72",
+    "zh:f698732a4391c3f4d7079b4aaa52389da2a460cac5eed438ed688f147d603689",
+    "zh:f9f51b17f2978394954e9f6ab9ef293b8e11f1443117294ccf87f7f8212b3439",
+  ]
+}

--- a/terragrunt/env/production/export/terragrunt.hcl
+++ b/terragrunt/env/production/export/terragrunt.hcl
@@ -1,0 +1,26 @@
+terraform {
+  source = "../../../aws//export"
+}
+
+dependencies {
+  paths = ["../buckets"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    raw_bucket_arn  = "arn:aws:s3:::mock-raw-bucket"
+    raw_bucket_name = "mock-raw-bucket"
+  }
+}
+
+inputs = {
+  raw_bucket_arn  = dependency.buckets.outputs.raw_bucket_arn
+  raw_bucket_name = dependency.buckets.outputs.raw_bucket_name
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Add a scheduled Lambda function that pulls Freshdesk ticket data each day and writes it to the Raw bucket.

The Lambda's export code will be coming in a subsequent PR.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621