### PR TITLE
fix: use commit SHA to tag Docker image

### DIFF
--- a/.github/workflows/docker-apply-production.yml
+++ b/.github/workflows/docker-apply-production.yml
@@ -11,7 +11,7 @@ on:
 env: 
   AWS_REGION: ca-central-1
   REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com
-  TAG_VERSION: ${{ github.ref_name }}
+  TAG_VERSION: ${{ github.sha }}
 
 permissions:
   id-token: write

--- a/export/platform/support/freshdesk/Makefile
+++ b/export/platform/support/freshdesk/Makefile
@@ -1,5 +1,3 @@
-.PHONY: build
-
 docker:
 	docker build --platform linux/amd64 --tag platform-support-freshdesk-export .
  


### PR DESCRIPTION
# Summary
Update the Docker build/push workflow to use the commit SHA to tag rather than the branch name.

Remove the extra `.PHONY` declaration in the Makefile.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621