### PR TITLE
feat: add alarms for failed Freshdesk exports

### DIFF
--- a/terragrunt/aws/alarms/outputs.tf
+++ b/terragrunt/aws/alarms/outputs.tf
@@ -1,0 +1,9 @@
+output "sns_topic_alarm_action_arn" {
+  description = "SNS topic ARN to send alarm actions to"
+  value       = aws_sns_topic.cloudwatch_alarm_action.arn
+}
+
+output "sns_topic_ok_action_arn" {
+  description = "SNS topic ARN to send ok actions to"
+  value       = aws_sns_topic.cloudwatch_ok_action.arn
+}

--- a/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
@@ -1,0 +1,29 @@
+resource "aws_cloudwatch_log_metric_filter" "platform_support_freshdesk_export" {
+  name           = "platform-support-freshdesk-export-error"
+  pattern        = "ERROR"
+  log_group_name = "/aws/lambda/${module.platform_support_freshdesk_export.function_name}"
+
+  metric_transformation {
+    name          = "platform-support-freshdesk-export-error"
+    namespace     = "data-lake"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "platform_support_freshdesk_export" {
+  alarm_name          = "platform-support-freshdesk-export-error"
+  alarm_description   = "Errors logged over 1 minute by the Platform / Support / Freshdesk export."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.platform_support_freshdesk_export.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.platform_support_freshdesk_export.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alarm_action_arn]
+  ok_actions    = [var.sns_topic_ok_action_arn]
+}

--- a/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
@@ -1,10 +1,10 @@
 resource "aws_cloudwatch_log_metric_filter" "platform_support_freshdesk_export" {
-  name           = "platform-support-freshdesk-export-error"
+  name           = "${local.freshdesk_lambda_name}-error"
   pattern        = "ERROR"
-  log_group_name = "/aws/lambda/${module.platform_support_freshdesk_export.function_name}"
+  log_group_name = "/aws/lambda/${local.freshdesk_lambda_name}"
 
   metric_transformation {
-    name          = "platform-support-freshdesk-export-error"
+    name          = "${local.freshdesk_lambda_name}-error"
     namespace     = "data-lake"
     value         = "1"
     default_value = "0"
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_log_metric_filter" "platform_support_freshdesk_export" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "platform_support_freshdesk_export" {
-  alarm_name          = "platform-support-freshdesk-export-error"
+  alarm_name          = "${local.freshdesk_lambda_name}-error"
   alarm_description   = "Errors logged over 1 minute by the Platform / Support / Freshdesk export."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"

--- a/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/freshdesk.tf
@@ -4,7 +4,7 @@
 module "platform_support_freshdesk_export" {
   source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.2.2"
 
-  lambda_name                = "platform-support-freshdesk-export"
+  lambda_name                = local.freshdesk_lambda_name
   lambda_schedule_expression = "cron(0 5 * * ? *)" # 5am UTC every day
   s3_arn_write_path          = "${var.raw_bucket_arn}/${local.freshdesk_export_path}/*"
 

--- a/terragrunt/aws/export/platform/support/freshdesk/locals.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/locals.tf
@@ -1,3 +1,4 @@
 locals {
   freshdesk_export_path = "platform/support/freshdesk"
+  freshdesk_lambda_name = "platform-support-freshdesk-export"
 }

--- a/terragrunt/aws/export/platform/support/freshdesk/variables.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/variables.tf
@@ -18,3 +18,13 @@ variable "raw_bucket_name" {
   description = "The name of the Raw bucket."
   type        = string
 }
+
+variable "sns_topic_alarm_action_arn" {
+  description = "The ARN of the SNS topic to send alarm actions to."
+  type        = string
+}
+
+variable "sns_topic_ok_action_arn" {
+  description = "The ARN of the SNS topic to send OK actions to."
+  type        = string
+}

--- a/terragrunt/aws/export/tasks.tf
+++ b/terragrunt/aws/export/tasks.tf
@@ -1,8 +1,11 @@
 module "platform_support_freshdesk_export" {
   source = "./platform/support/freshdesk"
 
-  freshdesk_api_key = var.freshdesk_api_key
-  raw_bucket_arn    = var.raw_bucket_arn
-  raw_bucket_name   = var.raw_bucket_name
+  freshdesk_api_key          = var.freshdesk_api_key
+  raw_bucket_arn             = var.raw_bucket_arn
+  raw_bucket_name            = var.raw_bucket_name
+  sns_topic_alarm_action_arn = var.sns_topic_alarm_action_arn
+  sns_topic_ok_action_arn    = var.sns_topic_ok_action_arn
+
   billing_tag_value = var.billing_tag_value
 }

--- a/terragrunt/aws/export/variables.tf
+++ b/terragrunt/aws/export/variables.tf
@@ -13,3 +13,13 @@ variable "raw_bucket_name" {
   description = "The name of the Raw bucket."
   type        = string
 }
+
+variable "sns_topic_alarm_action_arn" {
+  description = "The ARN of the SNS topic to send alarm actions to."
+  type        = string
+}
+
+variable "sns_topic_ok_action_arn" {
+  description = "The ARN of the SNS topic to send OK actions to."
+  type        = string
+}

--- a/terragrunt/env/production/export/terragrunt.hcl
+++ b/terragrunt/env/production/export/terragrunt.hcl
@@ -30,8 +30,8 @@ inputs = {
   raw_bucket_arn  = dependency.buckets.outputs.raw_bucket_arn
   raw_bucket_name = dependency.buckets.outputs.raw_bucket_name
 
-  sns_topic_alarm_action_arn = dependency.buckets.outputs.sns_topic_alarm_action_arn
-  sns_topic_ok_action_arn    = dependency.buckets.outputs.sns_topic_ok_action_arn
+  sns_topic_alarm_action_arn = dependency.alarms.outputs.sns_topic_alarm_action_arn
+  sns_topic_ok_action_arn    = dependency.alarms.outputs.sns_topic_ok_action_arn
 }
 
 include {

--- a/terragrunt/env/production/export/terragrunt.hcl
+++ b/terragrunt/env/production/export/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../buckets"]
+  paths = ["../buckets", "../alarms"]
 }
 
 dependency "buckets" {
@@ -16,9 +16,22 @@ dependency "buckets" {
   }
 }
 
+dependency "alarms" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    sns_topic_alarm_action_arn = "arn:aws:sns:ca-central-1:123456789012:mock-alarm-topic"
+    sns_topic_ok_action_arn    = "arn:aws:sns:ca-central-1:123456789012:mock-ok-topic"
+  }
+}
+
 inputs = {
   raw_bucket_arn  = dependency.buckets.outputs.raw_bucket_arn
   raw_bucket_name = dependency.buckets.outputs.raw_bucket_name
+
+  sns_topic_alarm_action_arn = dependency.buckets.outputs.sns_topic_alarm_action_arn
+  sns_topic_ok_action_arn    = dependency.buckets.outputs.sns_topic_ok_action_arn
 }
 
 include {


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm to catch failed Freshdesk export runs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621