### PR TITLE
fix: path to alarms dependency

### DIFF
--- a/terragrunt/env/production/export/terragrunt.hcl
+++ b/terragrunt/env/production/export/terragrunt.hcl
@@ -17,7 +17,7 @@ dependency "buckets" {
 }
 
 dependency "alarms" {
-  config_path                             = "../buckets"
+  config_path                             = "../alarms"
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {


### PR DESCRIPTION
# Summary
Update the export module's `alarms` dependency to reference the correct module.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621
- #95 