### PR TITLE
feat: add alarm for Lambda `Errors` metric

### DIFF
--- a/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
@@ -12,13 +12,29 @@ resource "aws_cloudwatch_log_metric_filter" "platform_support_freshdesk_export" 
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "platform_support_freshdesk_export" {
-  alarm_name          = "${local.freshdesk_lambda_name}-error"
+resource "aws_cloudwatch_metric_alarm" "platform_support_freshdesk_export_error_logged" {
+  alarm_name          = "${local.freshdesk_lambda_name}-error-logged"
   alarm_description   = "Errors logged over 1 minute by the Platform / Support / Freshdesk export."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.platform_support_freshdesk_export.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.platform_support_freshdesk_export.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_alarm_action_arn]
+  ok_actions    = [var.sns_topic_ok_action_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "platform_support_freshdesk_export_errors" {
+  alarm_name          = "${local.freshdesk_lambda_name}-errors"
+  alarm_description   = "Errors metric over 1 minute by the Platform / Support / Freshdesk export."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
   period              = "60"
   statistic           = "Sum"
   threshold           = "0"


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm to the Freshdesk export job that triggers if there are any `AWS/Lambda/Errors` metrics reported.

This will catch cases like Lambda failed invocations and timeouts.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621