### PR TITLE
fix: add `month` partition column

### DIFF
--- a/export/platform/support/freshdesk/main.py
+++ b/export/platform/support/freshdesk/main.py
@@ -168,6 +168,7 @@ class FreshdeskClient:
                         "source_label": SOURCE_LOOKUP.get(source_num, "Unknown"),
                         "created_at": ticket.get("created_at"),
                         "updated_at": ticket.get("updated_at"),
+                        "month": yesterday.strftime("%Y-%m"),
                         "due_by": ticket.get("due_by"),
                         "fr_due_by": ticket.get("fr_due_by"),
                         "is_escalated": ticket.get("is_escalated"),
@@ -213,7 +214,7 @@ def upload_to_s3(bucket, prefix, data):
     yesterday = datetime.now() - timedelta(days=1)
     day = yesterday.strftime("%Y-%m-%d")
     month = yesterday.strftime("%Y-%m")
-    key = f"{prefix}/MONTH={month}/{day}.json"
+    key = f"{prefix}/month={month}/{day}.json"
 
     s3_client.put_object(
         Bucket=bucket, Key=key, Body=json.dumps(data, ensure_ascii=False)

--- a/export/platform/support/freshdesk/main_test.py
+++ b/export/platform/support/freshdesk/main_test.py
@@ -21,6 +21,7 @@ MOCK_TICKET = {
     "source": 1,
     "created_at": "2024-01-01T00:00:00Z",
     "updated_at": "2024-01-01T12:00:00Z",
+    "month": "2024-01",
     "due_by": "2024-01-02T00:00:00Z",
     "fr_due_by": "2024-01-02T00:00:00Z",
     "is_escalated": False,


### PR DESCRIPTION
# Summary
Add the `month` partition column to the data exported for each ticket.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621