### PR TITLE
feat: add Glue database for transformed Freshdesk data

### DIFF
--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -3,6 +3,11 @@ resource "aws_glue_catalog_database" "platform_gc_forms_production" {
   description = "TRANSFORMED: data source path: /platform/gc-forms/*"
 }
 
+resource "aws_glue_catalog_database" "platform_support_production" {
+  name        = "platform_support_production"
+  description = "TRANSFORMED: data source path: /platform/support/*"
+}
+
 resource "aws_glue_catalog_database" "platform_support_production_raw" {
   name        = "platform_support_production_raw"
   description = "RAW: data source path: /platform/support/*"

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -5,6 +5,7 @@ locals {
   glue_catalog_databases = [
     "all", # special case for an IAM role with access to all databases
     aws_glue_catalog_database.platform_gc_forms_production.name,
+    aws_glue_catalog_database.platform_support_production.name,
     aws_glue_catalog_database.operations_aws_production.name,
   ]
   glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -5,7 +5,6 @@ locals {
   glue_catalog_databases = [
     "all", # special case for an IAM role with access to all databases
     aws_glue_catalog_database.platform_gc_forms_production.name,
-    aws_glue_catalog_database.platform_support_production.name,
     aws_glue_catalog_database.operations_aws_production.name,
   ]
   glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"


### PR DESCRIPTION
# Summary
Add a new AWS Glue database to hold the tables representing the transformed Freshdesk ticket data schema.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621