### PR TITLE
docs: add Freshdesk data pipeline and catalog docs

### DIFF
--- a/docs/data/catalog/README.md
+++ b/docs/data/catalog/README.md
@@ -1,6 +1,7 @@
 # Data catalog
 Provides an inventory that contains metadata, descriptions, and technical details about all data sources within the data lake.
 
+- [Platform / Support / Freshdesk](./platform/support/freshdesk.md)
 - [Operations / AWS / Cost and Usage Report](./operations/aws/cost-and-usage-report.md)
 
 :page_facing_up: When adding a new pipeline, please use [template.md](./template.md) as a starting point.

--- a/docs/data/catalog/operations/aws/cost-and-usage-report.md
+++ b/docs/data/catalog/operations/aws/cost-and-usage-report.md
@@ -4,7 +4,7 @@ Dataset describing how much was spent on Amazon Web Services (AWS) by CDS.
 
 Each row describes the cost of using a particular AWS service (i.e., a line item) within a billing period.
 
-This dataset is represented in [Superset](https://superset.cdssandbox.xyz/) as the Physical dataset [`cost_usage_report_by_account`](https://superset.cdssandbox.xyz/explore/?datasource_type=table&datasource_id=68). All of the Virtual datasets in the "Operations / AWS / Cost and Usage" group are derived from it.
+This dataset is represented in [Superset](https://superset.cds-snc.ca/) as the Physical dataset [`cost_usage_report_by_account`](https://superset.cds-snc.ca/explore/?datasource_type=table&datasource_id=68). All of the Virtual datasets in the "Operations / AWS / Cost and Usage" group are derived from it.
 
 **Keywords:** AWS, Amazon, cost, usage, fees
 

--- a/docs/data/catalog/operations/aws/cost-and-usage-report.md
+++ b/docs/data/catalog/operations/aws/cost-and-usage-report.md
@@ -6,7 +6,7 @@ Each row describes the cost of using a particular AWS service (i.e., a line item
 
 This dataset is represented in [Superset](https://superset.cds-snc.ca/) as the Physical dataset [`cost_usage_report_by_account`](https://superset.cds-snc.ca/explore/?datasource_type=table&datasource_id=68). All of the Virtual datasets in the "Operations / AWS / Cost and Usage" group are derived from it.
 
-**Keywords:** AWS, Amazon, cost, usage, fees
+`Keywords`: AWS, Amazon, cost, usage, fees
 
 ---
 
@@ -18,10 +18,10 @@ This dataset is extracted daily from the [Cost and Usage Report 2.0 (CUR 2.0)](h
 
 More documentation on the pipeline can be found [here](../../../pipelines/operations/aws/cost-and-usage-report.md).
 
-* **Updated:** Daily
-* **Steward:** Platform Core Services
-* **Contact:** [Pat Heard](mailto:patrick.heard@cds-snc.ca)
-* **Location:** s3://cds-data-lake-transformed-production/operations/aws/cost-usage-report/data/billing_period=YYYY-MM/*.parquet
+* `Updated`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: [Pat Heard](mailto:patrick.heard@cds-snc.ca)
+* `Location`: s3://cds-data-lake-transformed-production/operations/aws/cost-usage-report/data/billing_period=YYYY-MM/*.parquet
 
 ## Fields
 
@@ -31,151 +31,151 @@ Many columns are grouped together with a common prefix. For example, the `produc
 
 A query to return example data can be found [here](examples/cost-and-usage-report.sql).
 
-* **id** (integer) - AWS account ID for the line item.
-* **arn** (string) - Amazon Resource Name of the AWS account for the resource being billed.
-* **email** (string) - email associated with the AWS account for the line item.
-* **name** (string) - name of the AWS account for the line item.
-* **status** (string) - status of the line item's AWS account, one of "ACTIVE" or "INACTIVE".
-* **joinedmethod** (string) - how the AWS account was was added to the AWS organization, one of "CREATED" or "INVITED".
-* **joinedtimestamp** (string) - timestamp of AWS account's creation in UTC. Formatted as `YYYY-MM-DD HH:MM:SSz.`.
+* `id` (integer) - AWS account ID for the line item.
+* `arn` (string) - Amazon Resource Name of the AWS account for the resource being billed.
+* `email` (string) - email associated with the AWS account for the line item.
+* `name` (string) - name of the AWS account for the line item.
+* `status` (string) - status of the line item's AWS account, one of "ACTIVE" or "INACTIVE".
+* `joinedmethod` (string) - how the AWS account was was added to the AWS organization, one of "CREATED" or "INVITED".
+* `joinedtimestamp` (string) - timestamp of AWS account's creation in UTC. Formatted as `YYYY-MM-DD HH:MM:SSz.`.
 
 * `tag` columns, containing information about the member account business unit tags
-    * **tag_env** (string) - tag assigned to the environment.
-    * **tag_business_unit** (string) - business unit responsible for the service.
-    * **tag_product** (string) - product that uses this service.
+    * `tag_env` (string) - tag assigned to the environment.
+    * `tag_business_unit` (string) - business unit responsible for the service.
+    * `tag_product` (string) - product that uses this service.
 * `bill` columns, containing data about the bill for the billing period.
-    * **bill_bill_type** (string) - type of bill that this report covers. One of:
+    * `bill_bill_type` (string) - type of bill that this report covers. One of:
         * "Anniversary" - line items for the services used during the month.
         * "Purchase" - line items for upfront service fees.
         * "Refund" - line items for refunds.
-    * **bill_billing_entity** (string) - helps identify whether invoices are for AWS Marketplace or for purchases of other AWS services.
-    * **bill_billing_period_end_date** (datetime) - end date of the billing period that is covered by this report, in UTC. The format is `YYYY-MM-DDTHH:mm:ssZ`.
-    * **bill_billing_period_start_date** (datetime) - start date of the billing period that is covered by this report, in UTC. The format is `YYYY-MM-DDTHH:mm:ssZ`.
-    * **bill_invoice_id** (string) - ID associated with a specific line item. Until the report is final, `bill_invoice_id` is blank.
-    * **bill_invoicing_entity** (string) - AWS entity that issues the invoice.
-    * **bill_payer_account_id** - account ID of the paying account. For an organization in AWS Organizations, this is the account ID of the management account.
-    * **bill_payer_account_name** (string) - account name of the paying account. For an organization in AWS Organizations, this is the name of the management account.
+    * `bill_billing_entity` (string) - helps identify whether invoices are for AWS Marketplace or for purchases of other AWS services.
+    * `bill_billing_period_end_date` (datetime) - end date of the billing period that is covered by this report, in UTC. The format is `YYYY-MM-DDTHH:mm:ssZ`.
+    * `bill_billing_period_start_date` (datetime) - start date of the billing period that is covered by this report, in UTC. The format is `YYYY-MM-DDTHH:mm:ssZ`.
+    * `bill_invoice_id` (string) - ID associated with a specific line item. Until the report is final, `bill_invoice_id` is blank.
+    * `bill_invoicing_entity` (string) - AWS entity that issues the invoice.
+    * `bill_payer_account_id` - account ID of the paying account. For an organization in AWS Organizations, this is the account ID of the management account.
+    * `bill_payer_account_name` (string) - account name of the paying account. For an organization in AWS Organizations, this is the name of the management account.
 * `discount` columns, containing information about any discounts being received
-    * **discount_bundled_discount** (float) - bundled discount applied to the line item.
-    * **discount_total_discount** (float) - sum of all the discount columns for the corresponding line item.
+    * `discount_bundled_discount` (float) - bundled discount applied to the line item.
+    * `discount_total_discount` (float) - sum of all the discount columns for the corresponding line item.
 * `identity` columns, containing information that help identify a line item.
-    * **identity_line_item_id** (string) - generated for each line item and is unique in a given partition.
-    * **identity_time_interval** (string) - time interval that this line item applies to, in the format `YYYY-MM-DDTHH:mm:ssZ/YYYY-MM-DDTHH:mm:ssZ`
+    * `identity_line_item_id` (string) - generated for each line item and is unique in a given partition.
+    * `identity_time_interval` (string) - time interval that this line item applies to, in the format `YYYY-MM-DDTHH:mm:ssZ/YYYY-MM-DDTHH:mm:ssZ`
 * `line_item` columns, contain data about cost, usage, type of usage, pricing rates, product name, and more.
-    * **line_item_availability_zone** (string) - Availability Zone that hosts this line item. For example, us-east-1a or us-east-1b.
-    * **line_item_blended_cost** (float) - `time_item_blended_rate` * `line_item_usage_amount`
-    * **line_item_blended_rate** (float) - average cost incurred for each SKU across an organization.
-    * **line_item_currency_code** (string) - currency that this line item is shown in. All AWS customers are billed in US dollars (`USD`) by default.
-    * **line_item_legal_entity** (string) - Seller of Record of a specific product or service. In most cases, the invoicing entity and legal entity are the same.
-    * **line_item_line_item_description** (string) - description of the line item type. For example, the description of a usage line item summarizes the type of usage incurred during a specific time period.
-    * **line_item_line_item_type** (string) - type of charge covered by this line item. Common values are:
+    * `line_item_availability_zone` (string) - Availability Zone that hosts this line item. For example, us-east-1a or us-east-1b.
+    * `line_item_blended_cost` (float) - `time_item_blended_rate` * `line_item_usage_amount`
+    * `line_item_blended_rate` (float) - average cost incurred for each SKU across an organization.
+    * `line_item_currency_code` (string) - currency that this line item is shown in. All AWS customers are billed in US dollars (`USD`) by default.
+    * `line_item_legal_entity` (string) - Seller of Record of a specific product or service. In most cases, the invoicing entity and legal entity are the same.
+    * `line_item_line_item_description` (string) - description of the line item type. For example, the description of a usage line item summarizes the type of usage incurred during a specific time period.
+    * `line_item_line_item_type` (string) - type of charge covered by this line item. Common values are:
         * "Tax" - any taxes that AWS applied to bills. For example, VAT or US sales tax.
         * "Usage" - any usage that is charged at On-Demand Instance rates.
         * "Fee" - any upfront annual fee that are paid for subscriptions.
         * "Credit" - any credits that AWS applied to a bill. 
         * Nine other options not listed here. Refer to the [AWS Data Exports Dictionary](https://docs.aws.amazon.com/cur/latest/userguide/table-dictionary-cur2-line-item.html).
-    * **line_item_net_unblended_cost** (float) - actual after-discount cost that you're paying for the line item. 
-    * **line_item_net_unblended_rate** (string) - actual after-discount rate that you're paying for the line item. 
-    * **line_item_normalization_factor** (float) - as long as the instance has shared tenancy, AWS can apply all Regional Linux or Unix Amazon EC2 and Amazon RDS RI discounts to all instance sizes in an instance family and AWS Region. This also applies to RI discounts for member accounts in an organization. All new and existing Amazon EC2 and Amazon RDS size-flexible RIs are sized according to a normalization factor, based on the instance size.
-    * **line_item_normalized_usage_amount** (float) - amount of usage that you incurred, in normalized units, for size-flexible RIs. Calcuated as `line_item_usage_amount` * `line_item_normalization_factor`.
-    * **line_item_operation** (string) - specific AWS operation covered by this line item. This describes the specific usage of the line item.
-    * **line_item_product_code** (string) - code of the product measured.
-    * **line_item_resource_id** (string) - the ID of the resource that has been provisioned.
-    * **line_item_tax_type** (string) -  type of tax that AWS applied to this line item.
-    * **line_item_unblended_cost** (float) - `line_item_unblended_rate` * `line_item_usage_amount`.
-    * **line_item_unblended_rate** (string) - unblended rate is the rate associated with an individual account's service usage.
-    * **line_item_usage_account_id** (string) - account ID of the account that used this line item.
-    * **line_item_usage_account_name** (string) - account name that used this line item.
-    * **line_item_usage_amount** (float) - amount of usage that incurred during the specified time period.
-    * **line_item_usage_end_date** (datetime) - end date and time for the corresponding line item in UTC, exclusive. The format is `YYYY-MM-DDTHH:mm:ssZ`.
-    * **line_item_usage_start_date** (datetime) - start date and time for the corresponding line item in UTC, exclusive. The format is `YYYY-MM-DDTHH:mm:ssZ`.
-    * **line_item_usage_type** (string) - usage details of the line item.
+    * `line_item_net_unblended_cost` (float) - actual after-discount cost that you're paying for the line item. 
+    * `line_item_net_unblended_rate` (string) - actual after-discount rate that you're paying for the line item. 
+    * `line_item_normalization_factor` (float) - as long as the instance has shared tenancy, AWS can apply all Regional Linux or Unix Amazon EC2 and Amazon RDS RI discounts to all instance sizes in an instance family and AWS Region. This also applies to RI discounts for member accounts in an organization. All new and existing Amazon EC2 and Amazon RDS size-flexible RIs are sized according to a normalization factor, based on the instance size.
+    * `line_item_normalized_usage_amount` (float) - amount of usage that you incurred, in normalized units, for size-flexible RIs. Calcuated as `line_item_usage_amount` * `line_item_normalization_factor`.
+    * `line_item_operation` (string) - specific AWS operation covered by this line item. This describes the specific usage of the line item.
+    * `line_item_product_code` (string) - code of the product measured.
+    * `line_item_resource_id` (string) - the ID of the resource that has been provisioned.
+    * `line_item_tax_type` (string) -  type of tax that AWS applied to this line item.
+    * `line_item_unblended_cost` (float) - `line_item_unblended_rate` * `line_item_usage_amount`.
+    * `line_item_unblended_rate` (string) - unblended rate is the rate associated with an individual account's service usage.
+    * `line_item_usage_account_id` (string) - account ID of the account that used this line item.
+    * `line_item_usage_account_name` (string) - account name that used this line item.
+    * `line_item_usage_amount` (float) - amount of usage that incurred during the specified time period.
+    * `line_item_usage_end_date` (datetime) - end date and time for the corresponding line item in UTC, exclusive. The format is `YYYY-MM-DDTHH:mm:ssZ`.
+    * `line_item_usage_start_date` (datetime) - start date and time for the corresponding line item in UTC, exclusive. The format is `YYYY-MM-DDTHH:mm:ssZ`.
+    * `line_item_usage_type` (string) - usage details of the line item.
 * `pricing` columns, contain data about the pricing for a line item.
-    * **pricing_currency** (string) - currency that the pricing data is shown in.
-    * **pricing_lease_contract_length** (string) - length of time that your RI is reserved for.
-    * **pricing_offering_class** (string) - offering class of the Reserved Instance.
-    * **pricing_public_on_demand_cost** (float) -  total cost for the line item based on public On-Demand Instance rates. 
-    * **pricing_public_on_demand_rate** (string) - public On-Demand Instance rate in this billing period for the specific line item of usage.
-    * **pricing_purchase_option** (string) - how this line item is paid for, one of "All Upfront", "Partial Upfront", and "No Upfront".
-    * **pricing_rate_code** (string) - unique code for a product/offer/pricing-tier combination. 
-    * **pricing_rate_id** (string) - ID of the rate for a line item.
-    * **pricing_term** - (string) whether the AWS usage is "Reserved" or "On-Demand".
-    * **pricing_unit** (string) - pricing unit AWS used to calculate your usage cost.
+    * `pricing_currency` (string) - currency that the pricing data is shown in.
+    * `pricing_lease_contract_length` (string) - length of time that your RI is reserved for.
+    * `pricing_offering_class` (string) - offering class of the Reserved Instance.
+    * `pricing_public_on_demand_cost` (float) -  total cost for the line item based on public On-Demand Instance rates. 
+    * `pricing_public_on_demand_rate` (string) - public On-Demand Instance rate in this billing period for the specific line item of usage.
+    * `pricing_purchase_option` (string) - how this line item is paid for, one of "All Upfront", "Partial Upfront", and "No Upfront".
+    * `pricing_rate_code` (string) - unique code for a product/offer/pricing-tier combination. 
+    * `pricing_rate_id` (string) - ID of the rate for a line item.
+    * `pricing_term` - (string) whether the AWS usage is "Reserved" or "On-Demand".
+    * `pricing_unit` (string) - pricing unit AWS used to calculate your usage cost.
 * `product` columns contain data about the product that is being charged in the line item.
-    * **product_from_location_type** (string) - describes the location type where the usage originated from.
-    * **product_from_region_code** (string) - describes the source Region code for the AWS service.
-    * **product_instance_family** (string) - describes the Amazon EC2 instance family.
-    * **product_instance_type** (string) - describes the instance type, size, and family, which define the CPU, networking, and storage capacity of the instance.
-    * **product_instancesku** (string) - SKU (stock keeping unit) of the product instance
-    * **product_location** (string) - describes the Region that the Amazon S3 bucket resides in.
-    * **product_location_type** (string) - describes the endpoint of your task.
-    * **product_operation** (string) - describes the specific AWS operation that this line item covers.
-    * **product_pricing_unit** (string) - smallest billing unit for an AWS service. For example, 0.01c per API call.
-    * **product_product_family** (string) - category for the type of product.
-    * **product_region_code** (string) - a Region is a physical location around the world where data centers are clustered. AWS calls each group of logical data centers an Availability Zone (AZ). 
-    * **product_servicecode** (string) - identifies the specific AWS service to the customer as a unique short abbreviation.
-    * **product_sku** (string) - unique code for a product. The SKU is created by combining `line_item_product_code`, `line_item_usage_type`, and `product_operation`.
-    * **product_to_location** (string) - describes the location usage destination.
-    * **product_to_location_type** (string) - describes the destination location of the service usage.
-    * **product_to_region_code** (string) - describes the source Region code for the AWS service.
-    * **product_usagetype** (string) - describes the usage details of the line item.
-* `reservation` columns contain data about a reservation that applies to the line item. **As of December 2024, the way CDS uses AWS means that most of these fields are blank.**
-    * **reservation_amortized_upfront_cost_for_usage** (float) - initial upfront payment for all upfront RIs and partial upfront RIs (Reserved Instance) amortized for usage time.
-    * **reservation_amortized_upfront_fee_for_billing_period** (float) - escribes how much of the upfront fee for this reservation is costing you for the billing period.
-    * **reservation_availability_zone** (string) - Availability Zone of the resource that is associated with this line item.
-    * **reservation_effective_cost** (float) - sum of both the upfront and hourly rate of an RI, averaged into an effective hourly rate.
-    * **reservation_end_time** (string) - end date of the associated RI lease term.
-    * **reservation_modification_status** (string) - describes whether the RI lease was modified or if it is unaltered. One of "Original", "System", "Manual", or "ManualWithData".
-    * **reservation_net_amortized_upfront_cost_for_usage** (float) - initial upfront payment for All Upfront RIs and Partial Upfront RIs amortized for usage time, if applicable
-    * **reservation_net_amortized_upfront_fee_for_billing_period** (float) -  cost of the reservation's upfront fee for the billing period.
-    * **reservation_net_effective_cost** (float) - sum of both the upfront fee and the hourly rate of the RI, averaged into an effective hourly rate. 
-    * **reservation_net_recurring_fee_for_usage** (float) - after-discount cost of the recurring usage fee.
-    * **reservation_net_unused_amortized_upfront_fee_for_billing_period** (float) - net unused amortized upfront fee for the billing period.
-    * **reservation_net_unused_recurring_fee** (float) - recurring fees associated with unused reservation hours for Partial Upfront and No Upfront RIs after discounts.
-    * **reservation_net_upfront_value** (float) - upfront value of the RI with discounts applied.
-    * **reservation_normalized_units_per_reservation** (string) - number of normalized units for each instance of a reservation subscription.
-    * **reservation_number_of_reservations** (string) - number of reservations that are covered by this subscription.
-    * **reservation_recurring_fee_for_usage** (float) - recurring fee amortized for usage time, for partial upfront RIs and no upfront RIs. 
-    * **reservation_reservation_a_r_n** (string) - Amazon Resource Name (ARN) of the RI that this line item benefited from. This is also called the "RI Lease ID".
-    * **reservation_start_time** (string) - start date of the term of the associated Reserved Instance.
-    * **reservation_subscription_id** (string) - unique identifier that maps a line item with the associated offer
-    * **reservation_total_reserved_normalized_units** (string) - total number of reserved normalized units for all instances for a reservation subscription.
-    * **reservation_total_reserved_units** (string) - total number of reserved units for all instances for a reservation subscription.
-    * **reservation_units_per_reservation** (string) - total number of units per reservation
-    * **reservation_unused_amortized_upfront_fee_for_billing_period** (float) - amortized-upfront-fee-for-billing-period-column amortized portion of the initial upfront fee for all upfront RIs and partial upfront RIs.
-    * **reservation_unused_normalized_unit_quantity** (float) - number of unused normalized units for a size-flexible Regional RI that you didn't use during this billing period.
-    * **reservation_unused_quantity** (float) - number of RI hours that you didn't use during this billing period.
-    * **reservation_unused_recurring_fee** (float) - recurring fees associated with your unused reservation hours for partial upfront and no upfront RIs. 
-    * **reservation_upfront_value** (float) - upfront price paid for an AWS Reserved Instance.
-* `savings_plan` columns contain data about savings plans that apply to the line item. **As of December 2024, the way CDS uses AWS means that most of these fields are blank.**
-    * **savings_plan_end_time** (string) - expiration date for the Savings Plan agreement.
-    * **savings_plan_instance_type_family** (string) - instance family that is associated with the specified usage.
-    * **savings_plan_net_amortized_upfront_commitment_for_billing_period** (float) - cost of a Savings Plan subscription upfront fee for the billing period. 
-    * **savings_plan_net_recurring_commitment_for_billing_period** (float) - net unblended cost of the Savings Plan fee. 
-    * **savings_plan_net_savings_plan_effective_cost** (float) - effective cost for Savings Plans, which is the usage divided by the fees.
-    * **savings_plan_offering_type** (string) - describes the type of Savings Plan purchased.
-    * **savings_plan_payment_option** (string) - payment options available for your Savings Plan.
-    * **savings_plan_purchase_term** (string) - describes the duration, or term, of the Savings Plan.
-    * **savings_plan_recurring_commitment_for_billing_period** (float) - monthly recurring fee for your Savings Plan subscriptions. 
-    * **savings_plan_region** (string) - AWS Region (geographic area) that hosts your AWS services.
-    * **savings_plan_savings_plan_a_r_n** (string) - unique Savings Plan identifier.
-    * **savings_plan_savings_plan_effective_cost** (float) -  proportion of the Savings Plan monthly commitment amount (upfront and recurring) that is allocated to each usage line.
-    * **savings_plan_savings_plan_rate** (float) - Savings Plan rate for the usage.
-    * **savings_plan_start_time** (string) - start date of the Savings Plan agreement.
-    * **savings_plan_total_commitment_to_date** (float) - total amortized upfront commitment and recurring commitment to date, for that hour.
+    * `product_from_location_type` (string) - describes the location type where the usage originated from.
+    * `product_from_region_code` (string) - describes the source Region code for the AWS service.
+    * `product_instance_family` (string) - describes the Amazon EC2 instance family.
+    * `product_instance_type` (string) - describes the instance type, size, and family, which define the CPU, networking, and storage capacity of the instance.
+    * `product_instancesku` (string) - SKU (stock keeping unit) of the product instance
+    * `product_location` (string) - describes the Region that the Amazon S3 bucket resides in.
+    * `product_location_type` (string) - describes the endpoint of your task.
+    * `product_operation` (string) - describes the specific AWS operation that this line item covers.
+    * `product_pricing_unit` (string) - smallest billing unit for an AWS service. For example, 0.01c per API call.
+    * `product_product_family` (string) - category for the type of product.
+    * `product_region_code` (string) - a Region is a physical location around the world where data centers are clustered. AWS calls each group of logical data centers an Availability Zone (AZ). 
+    * `product_servicecode` (string) - identifies the specific AWS service to the customer as a unique short abbreviation.
+    * `product_sku` (string) - unique code for a product. The SKU is created by combining `line_item_product_code`, `line_item_usage_type`, and `product_operation`.
+    * `product_to_location` (string) - describes the location usage destination.
+    * `product_to_location_type` (string) - describes the destination location of the service usage.
+    * `product_to_region_code` (string) - describes the source Region code for the AWS service.
+    * `product_usagetype` (string) - describes the usage details of the line item.
+* `reservation` columns contain data about a reservation that applies to the line item. `As of December 2024, the way CDS uses AWS means that most of these fields are blank.`
+    * `reservation_amortized_upfront_cost_for_usage` (float) - initial upfront payment for all upfront RIs and partial upfront RIs (Reserved Instance) amortized for usage time.
+    * `reservation_amortized_upfront_fee_for_billing_period` (float) - escribes how much of the upfront fee for this reservation is costing you for the billing period.
+    * `reservation_availability_zone` (string) - Availability Zone of the resource that is associated with this line item.
+    * `reservation_effective_cost` (float) - sum of both the upfront and hourly rate of an RI, averaged into an effective hourly rate.
+    * `reservation_end_time` (string) - end date of the associated RI lease term.
+    * `reservation_modification_status` (string) - describes whether the RI lease was modified or if it is unaltered. One of "Original", "System", "Manual", or "ManualWithData".
+    * `reservation_net_amortized_upfront_cost_for_usage` (float) - initial upfront payment for All Upfront RIs and Partial Upfront RIs amortized for usage time, if applicable
+    * `reservation_net_amortized_upfront_fee_for_billing_period` (float) -  cost of the reservation's upfront fee for the billing period.
+    * `reservation_net_effective_cost` (float) - sum of both the upfront fee and the hourly rate of the RI, averaged into an effective hourly rate. 
+    * `reservation_net_recurring_fee_for_usage` (float) - after-discount cost of the recurring usage fee.
+    * `reservation_net_unused_amortized_upfront_fee_for_billing_period` (float) - net unused amortized upfront fee for the billing period.
+    * `reservation_net_unused_recurring_fee` (float) - recurring fees associated with unused reservation hours for Partial Upfront and No Upfront RIs after discounts.
+    * `reservation_net_upfront_value` (float) - upfront value of the RI with discounts applied.
+    * `reservation_normalized_units_per_reservation` (string) - number of normalized units for each instance of a reservation subscription.
+    * `reservation_number_of_reservations` (string) - number of reservations that are covered by this subscription.
+    * `reservation_recurring_fee_for_usage` (float) - recurring fee amortized for usage time, for partial upfront RIs and no upfront RIs. 
+    * `reservation_reservation_a_r_n` (string) - Amazon Resource Name (ARN) of the RI that this line item benefited from. This is also called the "RI Lease ID".
+    * `reservation_start_time` (string) - start date of the term of the associated Reserved Instance.
+    * `reservation_subscription_id` (string) - unique identifier that maps a line item with the associated offer
+    * `reservation_total_reserved_normalized_units` (string) - total number of reserved normalized units for all instances for a reservation subscription.
+    * `reservation_total_reserved_units` (string) - total number of reserved units for all instances for a reservation subscription.
+    * `reservation_units_per_reservation` (string) - total number of units per reservation
+    * `reservation_unused_amortized_upfront_fee_for_billing_period` (float) - amortized-upfront-fee-for-billing-period-column amortized portion of the initial upfront fee for all upfront RIs and partial upfront RIs.
+    * `reservation_unused_normalized_unit_quantity` (float) - number of unused normalized units for a size-flexible Regional RI that you didn't use during this billing period.
+    * `reservation_unused_quantity` (float) - number of RI hours that you didn't use during this billing period.
+    * `reservation_unused_recurring_fee` (float) - recurring fees associated with your unused reservation hours for partial upfront and no upfront RIs. 
+    * `reservation_upfront_value` (float) - upfront price paid for an AWS Reserved Instance.
+* `savings_plan` columns contain data about savings plans that apply to the line item. `As of December 2024, the way CDS uses AWS means that most of these fields are blank.`
+    * `savings_plan_end_time` (string) - expiration date for the Savings Plan agreement.
+    * `savings_plan_instance_type_family` (string) - instance family that is associated with the specified usage.
+    * `savings_plan_net_amortized_upfront_commitment_for_billing_period` (float) - cost of a Savings Plan subscription upfront fee for the billing period. 
+    * `savings_plan_net_recurring_commitment_for_billing_period` (float) - net unblended cost of the Savings Plan fee. 
+    * `savings_plan_net_savings_plan_effective_cost` (float) - effective cost for Savings Plans, which is the usage divided by the fees.
+    * `savings_plan_offering_type` (string) - describes the type of Savings Plan purchased.
+    * `savings_plan_payment_option` (string) - payment options available for your Savings Plan.
+    * `savings_plan_purchase_term` (string) - describes the duration, or term, of the Savings Plan.
+    * `savings_plan_recurring_commitment_for_billing_period` (float) - monthly recurring fee for your Savings Plan subscriptions. 
+    * `savings_plan_region` (string) - AWS Region (geographic area) that hosts your AWS services.
+    * `savings_plan_savings_plan_a_r_n` (string) - unique Savings Plan identifier.
+    * `savings_plan_savings_plan_effective_cost` (float) -  proportion of the Savings Plan monthly commitment amount (upfront and recurring) that is allocated to each usage line.
+    * `savings_plan_savings_plan_rate` (float) - Savings Plan rate for the usage.
+    * `savings_plan_start_time` (string) - start date of the Savings Plan agreement.
+    * `savings_plan_total_commitment_to_date` (float) - total amortized upfront commitment and recurring commitment to date, for that hour.
 * `split_line_item` columns
-    * **split_line_item_actual_usage** (float) - usage for vCPU or memory (based on lineItem/UsageType) you incurred for the specified time period for the Amazon ECS task or Kubernetes pod.
-    * **split_line_item_net_split_cost** (float) - effective cost for Amazon ECS tasks or Kubernetes pods after all discounts have been applied. 
-    * **split_line_item_net_unused_cost** (float) - effective unused cost for Amazon ECS tasks or Kubernetes pods after all discounts have been applied. 
-    * **split_line_item_parent_resource_id** (float) - resource ID of the parent EC2 instance associated with the Amazon ECS task or Amazon EKS pod.
-    * **split_line_item_public_on_demand_split_cost** (float) - cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod based on public On-Demand Instance rates.
-    * **split_line_item_public_on_demand_unused_cost** (float) - unused cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod based on public On-Demand Instance rates. 
-    * **split_line_item_reserved_usage** (float) - usage for vCPU or memory (based on lineItem/UsageType) that have been configured for the specified time period for the Amazon ECS task or Kubernetes pod.
-    * **split_line_item_split_cost** (float) - cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod
-    * **split_line_item_split_usage** (float) - usage for vCPU or memory (based on lineItem/UsageType) allocated for the specified time period to the Amazon ECS task or Kubernetes pod. 
-    * **split_line_item_split_usage_ratio** (float) - ratio of vCPU or memory (based on lineItem/UsageType) allocated to the Amazon ECS task or Kubernetes pod compared to the overall CPU or memory available on the EC2 instance 
-    * **split_line_item_unused_cost** (float) - unused cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod.
-* **billing_period** (string) - billing period for the line item, in the format `mmm-YYYY`
+    * `split_line_item_actual_usage` (float) - usage for vCPU or memory (based on lineItem/UsageType) you incurred for the specified time period for the Amazon ECS task or Kubernetes pod.
+    * `split_line_item_net_split_cost` (float) - effective cost for Amazon ECS tasks or Kubernetes pods after all discounts have been applied. 
+    * `split_line_item_net_unused_cost` (float) - effective unused cost for Amazon ECS tasks or Kubernetes pods after all discounts have been applied. 
+    * `split_line_item_parent_resource_id` (float) - resource ID of the parent EC2 instance associated with the Amazon ECS task or Amazon EKS pod.
+    * `split_line_item_public_on_demand_split_cost` (float) - cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod based on public On-Demand Instance rates.
+    * `split_line_item_public_on_demand_unused_cost` (float) - unused cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod based on public On-Demand Instance rates. 
+    * `split_line_item_reserved_usage` (float) - usage for vCPU or memory (based on lineItem/UsageType) that have been configured for the specified time period for the Amazon ECS task or Kubernetes pod.
+    * `split_line_item_split_cost` (float) - cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod
+    * `split_line_item_split_usage` (float) - usage for vCPU or memory (based on lineItem/UsageType) allocated for the specified time period to the Amazon ECS task or Kubernetes pod. 
+    * `split_line_item_split_usage_ratio` (float) - ratio of vCPU or memory (based on lineItem/UsageType) allocated to the Amazon ECS task or Kubernetes pod compared to the overall CPU or memory available on the EC2 instance 
+    * `split_line_item_unused_cost` (float) - unused cost for vCPU or memory (based on lineItem/UsageType) allocated for the time period to the Amazon ECS task or Kubernetes pod.
+* `billing_period` (string) - billing period for the line item, in the format `mmm-YYYY`
 
 ## Notes
 

--- a/docs/data/catalog/platform/support/examples/freshdesk.sql
+++ b/docs/data/catalog/platform/support/examples/freshdesk.sql
@@ -1,5 +1,5 @@
 /*
-This query will return the first ten rows of the "AWS Cost and Usage Report"
+This query will return the first ten rows of the "Freshdesk"
 dataset. To run it, open the SQL Lab in Superset and cut and paste the whole
 query into the query window.
 
@@ -12,5 +12,5 @@ visibility to only those with Superset access.
 SELECT
   *
 FROM
-  operations_aws_production.cost_usage_report_by_account 
+  platform_support_production.platform_support_freshdesk 
 LIMIT 10;

--- a/docs/data/catalog/platform/support/freshdesk.md
+++ b/docs/data/catalog/platform/support/freshdesk.md
@@ -1,0 +1,62 @@
+# Platform / Support / Freshdesk
+
+Dataset providing [Freshdesk](https://www.freshworks.com/freshdesk/) support ticket data raised by the users of CDS products.
+
+Each row is a Freshdesk ticket that does not include any personally identifiable information (PII) or user entered content.
+
+This dataset is represented in [Superset](https://superset.cds-snc.ca/) as the Physical dataset `platform_support_freshdesk`. 
+
+`Keywords`: Platform, Freshdesk, support, tickets
+
+---
+
+[:information_source:  View the data pipeline](../../../pipelines/platform/support/freshdesk.md)
+
+## Provenance
+
+This dataset is extracted daily using the Freshdesk API.  Each day the extract process downloads all tickets from the previous day that have been updated or created.  These tickets are then merged with the existing tickets in the dataset.
+
+More documentation on the pipeline can be found [here](../../../pipelines/platform/support/freshdesk.md).
+
+* `Updated`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: [Pat Heard](mailto:patrick.heard@cds-snc.ca)
+* `Location`: s3://cds-data-lake-transformed-production/platform/support/freshdesk/month=YYYY-MM/*.parquet
+
+## Fields
+
+Almost all fields are sourced directly from Freshdesk's [Tickets](https://developers.freshdesk.com/api/#tickets), [Contacts](https://developers.freshdesk.com/api/#contacts), and [Conversations](https://developers.freshdesk.com/api/#conversations) API endpoints.
+
+A [query to return example data](examples/freshdesk.sql) has also been provided.
+
+Here's a descriptive list of the Freshdesk ticket fields:
+
+* `id` (bigint) - Unique identifier for each support ticket.
+* `status` (bigint) - Numerical code representing the ticket's current status.
+* `status_label` (string) - Human-readable label for the ticket status (e.g., "Open", "Pending", "Resolved").
+* `priority` (bigint) - Numerical code indicating the ticket's priority level.
+* `priority_label` (string) - Human-readable label for the priority level (e.g., "Low", "Medium", "High", "Urgent").
+* `source` (bigint) - Numerical code indicating how the ticket was created.
+* `source_label` (string) - Human-readable label for the ticket source (e.g., "Email", "Phone", "Portal", "Chat").
+* `created_at` (timestamp) - Date and time when the ticket was initially created.
+* `updated_at` (timestamp) - Date and time of the most recent update to the ticket.
+* `due_by` (timestamp) - Deadline for ticket resolution based on support policies.
+* `fr_due_by` (timestamp) - First response due time based on support policies.
+* `is_escalated` (boolean) - Indicates whether the ticket has been escalated to a higher support tier.
+* `tags` (array<string>) - List of labels or categories assigned to the ticket for classification.
+* `spam` (boolean) - Indicates whether the ticket has been marked as spam.
+* `requester_email_suffix` (string) - Domain portion of the requester's email address.  For non Government of Canada users, this will have the value of `external`.
+* `type` (string) - Classification of the ticket type.
+* `product_id` (bigint) - Unique identifier for the product associated with the ticket.
+* `product_name` (string) - Name of the product associated with the ticket.
+* `conversations_total_count` (bigint) - Total number of messages in the ticket thread.
+* `conversations_reply_count` (bigint) - Number of replies to and from the user in the ticket thread.
+* `conversations_note_count` (bigint) - Number of internal notes from the support team added to the ticket.
+* `language` (string) - Primary language used in the ticket communication.
+* `province_or_territory` (string) - Canadian province or territory where the ticket originated.
+* `organization` (string) - Government of Canada department or crown corporation associated with the ticket requester.
+* `month` (string) - Month of ticket creation, used as a partition key for data organization.
+
+## Notes
+
+The `language`, `province_or_territory` and `organization` fields are custom fields managed by the Platform Support team.  As such, they will not always have a value populated in the dataset.

--- a/docs/data/catalog/template.md
+++ b/docs/data/catalog/template.md
@@ -20,7 +20,7 @@ Briefly describe where the dataset comes from using words. If from a database, i
 
 ## Fields
 
-[Link to the first 10-20 rows of the table as CSV](http://www.example.com/dataset.csv). If the head of the table is not representative (e.g., missing data) or sensitive (contains PII), more appropriate rows may be selected instead. Alternatively, a [SQL query](http://www.example.com/dataset.sql) may be provided that returns appropriate example data. This query must be complete, so much that it can be run directly in [Superset's SQL Lab](https://superset.cdssandbox.xyz/sqllab/) without modification.
+[Link to the first 10-20 rows of the table as CSV](http://www.example.com/dataset.csv). If the head of the table is not representative (e.g., missing data) or sensitive (contains PII), more appropriate rows may be selected instead. Alternatively, a [SQL query](http://www.example.com/dataset.sql) may be provided that returns appropriate example data. This query must be complete, so much that it can be run directly in [Superset's SQL Lab](https://superset.cds-snc.ca/sqllab/) without modification.
 
 A bulleted list of field names must be included, alongside a brief description of the field. Boolean descriptions can simply be the question answered by the boolean. The data type of a field and the unit of measurement should be included as well. The names of data types are dictated by the storage format. For example, the Parquet storage format commonly includes include booleans, dates, floats, integers, strings, times, and timestamps. There is no need to include the integer or float width unless the circumstances are exceptional. 
 

--- a/docs/data/catalog/template.md
+++ b/docs/data/catalog/template.md
@@ -6,17 +6,17 @@ An additional line that describes what each row in the table represents.
 
 If a data pipeline doc exists for this dataset, provide a link to it as well.
 
-**Keywords:** Example, keywords, help, when, searching
+`Keywords`: Example, keywords, help, when, searching
 
 ## Provenance
 
 Briefly describe where the dataset comes from using words. If from a database, indicate the table or view it is derived from, as well as any critical transformations or filters applied. If the dataset is sourced from a public distribution, link the repo or website where the dataset can be found. If the dataset is collected based on an experiment or survey, link the protocol where analysts can find more details.
 
-* **Updated:** Frequency of update, if automated. If manual, indicate "Manually"
-* **Last Updated:** (if manual) Date/time of last time dataset was update
-* **Steward:** Who is responsible for the data. This can be a person or an organization.
-* **Contact:** Email address or Slack handle of where queries should be directed
-* **Location:** (optional) Path to S3 bucket
+* `Updated`: Frequency of update, if automated. If manual, indicate "Manually"
+* `Last Updated`: (if manual) Date/time of last time dataset was update
+* `Steward`: Who is responsible for the data. This can be a person or an organization.
+* `Contact`: Email address or Slack handle of where queries should be directed
+* `Location`: (optional) Path to S3 bucket
 
 ## Fields
 
@@ -30,14 +30,14 @@ For string columns with only a few options (i.e., factors), include what the pos
 
 A few field examples:
 
-* **id** (string) - version 4 UUID that identifies the user
-* **registration_date** (datetime) - when the user registered, in UTC
-* **age** (integer) - user's age at registration, in years
-* **first_name** (string) - user's first or given name
-* **user_hometown** (string) - user's home town
-* **height** (float) - user's height in centimeters, converted from feet/inches depending on user's localization settings
-* **pizza_opinion** (string) - how much the user indicated they like pizza, one of "Delicious", "It's Alright" or "Hate It". May be missing if user registered before June 20, 2022.
-* **first_time_login** (boolean) - has the user logged into their account after completing registration?
+* `id` (string) - version 4 UUID that identifies the user
+* `registration_date` (datetime) - when the user registered, in UTC
+* `age` (integer) - user's age at registration, in years
+* `first_name` (string) - user's first or given name
+* `user_hometown` (string) - user's home town
+* `height` (float) - user's height in centimeters, converted from feet/inches depending on user's localization settings
+* `pizza_opinion` (string) - how much the user indicated they like pizza, one of "Delicious", "It's Alright" or "Hate It". May be missing if user registered before June 20, 2022.
+* `first_time_login` (boolean) - has the user logged into their account after completing registration?
 
 
 ## Notes (optional)

--- a/docs/data/pipelines/README.md
+++ b/docs/data/pipelines/README.md
@@ -1,6 +1,7 @@
 # Data pipelines
 Provides details on the automated processes that import and transform the data sources that are part of the data lake.
 
+- [Platform / Support / Freshdesk](./platform/support/freshdesk.md)
 - [Operations / AWS / Cost and Usage Report](./operations/aws/cost-and-usage-report.md)
 
 :page_facing_up: When adding a new pipeline, please use [template.md](./template.md) as a starting point.

--- a/docs/data/pipelines/platform/support/freshdesk.md
+++ b/docs/data/pipelines/platform/support/freshdesk.md
@@ -1,6 +1,6 @@
 # Platform / Support / Freshdesk
 ## Description
-The Freshdesk dataset provides information on user support tickets in [Parquet format](https://parquet.apache.org/). All user entered information and personally identifiable information (PII) has been removed from the dataset. The data is partitioned by month, and updated daily.
+The [Freshdesk](https://www.freshworks.com/freshdesk/) dataset provides information on user support tickets in [Parquet format](https://parquet.apache.org/). All user entered information and personally identifiable information (PII) has been removed from the dataset. The data is partitioned by month, and updated daily.
 
 This data pipeline creates the Glue data catalog table `platform_support_freshdesk` in the `platform_support_production` database.  It can be queried in Superset as follows:
 
@@ -46,14 +46,14 @@ graph TD
 ```
 
 ### Source data
-The [Freshdesk data export](https://github.com/cds-snc/data-lake/tree/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/export/platform/support/freshdesk) is run in the `DataLake-Production` account [ `platform-support-freshdesk-export` Lambda function](https://github.com/cds-snc/data-lake/tree/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/export/platform/support/freshdesk) that is triggered each day.  On each run it saves any updated tickets from the previous day to the Raw S3 bucket in a `YYYY-MM-DD.json` file:
+The [Freshdesk data export](https://github.com/cds-snc/data-lake/tree/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/export/platform/support/freshdesk) is run in the `DataLake-Production` account's [ `platform-support-freshdesk-export` Lambda function](https://github.com/cds-snc/data-lake/tree/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/export/platform/support/freshdesk) that is triggered each day.  On each run it saves any updated tickets from the previous day to the Raw S3 bucket in a `YYYY-MM-DD.json` file:
 
 ```
 cds-data-lake-raw-production/platform/support/freshdesk/month=YYYY-MM/YYYY-MM-DD.json
 ```
 
 ### Crawlers
-On the first of each month, an AWS Glue crawler run in the `DataLake-Production` AWS account to identify schema changes and update the Glue data catalog:
+On the first of each month, an AWS Glue crawler runs in the `DataLake-Production` AWS account to identify schema changes and update the Glue data catalog:
 
 - [Platform / Support / Freshdesk](https://github.com/cds-snc/data-lake/blob/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/glue/crawlers.tf#L49-L79)
 

--- a/docs/data/pipelines/platform/support/freshdesk.md
+++ b/docs/data/pipelines/platform/support/freshdesk.md
@@ -1,0 +1,74 @@
+# Platform / Support / Freshdesk
+## Description
+The Freshdesk dataset provides information on user support tickets in [Parquet format](https://parquet.apache.org/). All user entered information and personally identifiable information (PII) has been removed from the dataset. The data is partitioned by month, and updated daily.
+
+This data pipeline creates the Glue data catalog table `platform_support_freshdesk` in the `platform_support_production` database.  It can be queried in Superset as follows:
+
+```sql
+SELECT 
+    * 
+FROM 
+    "platform_support_production"."platform_support_freshdesk" 
+LIMIT 10;
+```
+
+---
+
+[:information_source:  View the data catalog](../../../catalog/platform/support/freshdesk.md)
+
+## Data pipeline
+A high level view is shown below with more details about each step following the diagram.
+
+```mermaid
+graph TD
+    %% Source Systems
+    Lambda["`**Lambda (Daily)**<br>Export Freshdesk tickets`"]
+    
+    %% Storage
+    RawS3["`**S3 Bucket (Raw)**<br/>cds-data-lake-raw-production`"]
+    TransS3["`**S3 Bucket (Transformed)**<br/>cds-data-lake-transformed-production`"]
+    
+    %% Processing
+    Crawlers["Crawlers (Monthly)"]
+    CatalogRaw["`**Data Catalog (Raw)**<br/>platform_support_freshdesk_raw`"]
+    CatalogTransformed["`**Data Catalog (Transformed)**<br/>platform_support_freshdesk`"]
+    ETL["ETL Job (Daily)"]
+
+    %% Flow
+    subgraph datalake[Data Lake account]
+        Lambda --> |YYYY-MM-DD.json|RawS3
+        RawS3 --> Crawlers
+        Crawlers --> |Updates Schema|CatalogRaw
+        CatalogRaw --> ETL
+        ETL --> TransS3
+        ETL --> CatalogTransformed
+    end
+```
+
+### Source data
+The [Freshdesk data export](https://github.com/cds-snc/data-lake/tree/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/export/platform/support/freshdesk) is run in the `DataLake-Production` account [ `platform-support-freshdesk-export` Lambda function](https://github.com/cds-snc/data-lake/tree/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/export/platform/support/freshdesk) that is triggered each day.  On each run it saves any updated tickets from the previous day to the Raw S3 bucket in a `YYYY-MM-DD.json` file:
+
+```
+cds-data-lake-raw-production/platform/support/freshdesk/month=YYYY-MM/YYYY-MM-DD.json
+```
+
+### Crawlers
+On the first of each month, an AWS Glue crawler run in the `DataLake-Production` AWS account to identify schema changes and update the Glue data catalog:
+
+- [Platform / Support / Freshdesk](https://github.com/cds-snc/data-lake/blob/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/glue/crawlers.tf#L49-L79)
+
+This crawler creates and manages the following data catalog table in the [`platform_support_production_raw` database](https://github.com/cds-snc/data-lake/blob/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/glue/databases.tf#L11-L14):
+
+- `platform_support_freshdesk`: Freshdesk ticket data with no PII or user entered information.
+
+### Extract, Transform and Load (ETL) Jobs
+
+Each day, the [`Platform / Support / Freshdesk` Glue ETL job](https://github.com/cds-snc/data-lake/blob/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/glue/etl.tf#L39-L108) runs and updates existing tickets as well as adding new tickets.  The resulting data is saved in the data lake's Transformed `cds-data-lake-transformed-production` S3 bucket:
+
+```
+cds-data-lake-transformed-production/platform/support/freshdesk/month=YYYY-MM/*.parquet
+```
+
+Additionally, a data catalog table is created in the [`platform_support_production` database](https://github.com/cds-snc/data-lake/blob/6d3aea78d5d5a47d318ca66d37f0d4af6972fca4/terragrunt/aws/glue/databases.tf#L6-L9):
+
+- `platform_support_freshdesk`: Freshdesk ticket data with no PII or user entered information.


### PR DESCRIPTION
# Summary
Add docs for the new Freshdesk dataset.

Rendered views:
- [Pipeline](https://github.com/cds-snc/data-lake/blob/docs/freshdesk-dataset/docs/data/pipelines/platform/support/freshdesk.md)
- [Catalog](https://github.com/cds-snc/data-lake/blob/docs/freshdesk-dataset/docs/data/catalog/platform/support/freshdesk.md)

Additionally, this PR updates the data catalog template to use code blocks rather than bolding for labels.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621