### PR TITLE
fix: re-add operations_aws_production database

### DIFF
--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -4,7 +4,7 @@ locals {
   # The Superset role ARNs are managed by the `superset_iam_role_arns` input variable.
   glue_catalog_databases = [
     "all", # special case for an IAM role with access to all databases
-    aws_glue_catalog_database.platform_gc_forms_production.name,
+    aws_glue_catalog_database.operations_aws_production.name,
     aws_glue_catalog_database.platform_gc_forms_production.name,
     aws_glue_catalog_database.platform_support_production.name,
   ]


### PR DESCRIPTION
# Summary
Re-add the Operations AWS production database which was accidentally deleted while adding the Platform Support production database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621
- #111 