### PR TITLE
feat: onboard Freshdesk data to Superset prod

### DIFF
--- a/terragrunt/env/root.hcl
+++ b/terragrunt/env/root.hcl
@@ -10,6 +10,7 @@ inputs = {
   superset_iam_role_arns = [
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-all",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-operations_aws_production",
+    "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_support_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-all",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_gc_forms_production",


### PR DESCRIPTION
# Summary
Allow Superset production to access the Freshdesk dataset.

⚠️  This must wait until cds-snc/cds-superset#281 has been released to prod otherwise the Terraform apply will fail since the IAM role won't exist yet.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621
- https://github.com/cds-snc/cds-superset/pull/281