### PR TITLE
feat: increase Freshdesk ETL window to 1 year

### DIFF
--- a/terragrunt/aws/glue/etl/platform/support/freshdesk/scripts/process_tickets.py
+++ b/terragrunt/aws/glue/etl/platform/support/freshdesk/scripts/process_tickets.py
@@ -170,8 +170,8 @@ def process_tickets():
     if not validate_schema(new_tickets, glue_table_schema):
         raise ValueError("Schema validation failed. Aborting ETL process.")
 
-    # Load 4 months of existing ticket data
-    start_date = datetime.now(UTC) - relativedelta(months=4)
+    # Load 1 year of existing ticket data
+    start_date = datetime.now(UTC) - relativedelta(years=1)
     existing_tickets = get_existing_tickets(start_date)
 
     # Merge the existing and new tickets and save


### PR DESCRIPTION
# Summary
Update the Freshdesk ETL so that when it is processing the new tickets it looks back a full year to see if there already a record for the ticket.

This will futher reduce the chance of ending up with duplicate tickets in the dataset.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621