### PR TITLE
fix: update Freshdesk crawler to run more

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -77,7 +77,7 @@ resource "aws_glue_crawler" "platform_support_freshdesk_production" {
       Version              = 1
   })
 
-  schedule = "cron(00 6 1 * ? *)" # 6am UTC check for schema changes on the first day of each month
+  schedule = "cron(00 6 1-10 * ? *)" # 6am UTC check for schema changes on the first 10 days of each month
 }
 
 #


### PR DESCRIPTION
# Summary
Update the Freshdesk crawler to run for the first 10 days of each month.  This will catch scenarios where the first of the month falls on a weekend or holiday.