### PR TITLE
fix: Freshdesk API rate limiting on export

### DIFF
--- a/export/platform/support/freshdesk/main.py
+++ b/export/platform/support/freshdesk/main.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from datetime import datetime, timedelta
+from time import sleep
 
 import boto3
 import requests
@@ -197,6 +198,7 @@ class FreshdeskClient:
                 if len(tickets.get("results", [])) == per_page:
                     logger.info(f"Fetching page {page + 1}...")
                     page += 1
+                    sleep(30)  # Avoid rate limiting
                 else:
                     logger.info("All tickets fetched")
                     break

--- a/export/platform/support/freshdesk/main_test.py
+++ b/export/platform/support/freshdesk/main_test.py
@@ -135,7 +135,7 @@ class TestFreshdeskClient:
             assert ticket["conversations_total_count"] == 3
 
     def test_get_tickets_pagination(self, mock_freshdesk_client):
-        with patch("requests.get") as mock_get:
+        with patch("requests.get") as mock_get, patch("main.sleep") as mock_sleep:
             mock_get.return_value.status_code = 200
             mock_get.return_value.json.side_effect = [
                 {"results": [MOCK_TICKET for i in range(1, 31)]},
@@ -155,6 +155,7 @@ class TestFreshdeskClient:
 
             tickets = mock_freshdesk_client.get_tickets()
             assert len(tickets) == 64
+            assert mock_sleep.call_count == 2
 
 
 def test_upload_to_s3(mock_s3_client):


### PR DESCRIPTION
# Summary
Add a sleep between Freshdesk API page retrieval to avoid rate limiting errors.