### PR TITLE
fix: allow `pythonshell` ETL jobs to log to CloudWatch

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -165,7 +165,7 @@ data "aws_iam_policy_document" "glue_kms" {
     resources = [
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/crawlers*",
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/jobs*",
-      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/python-jobs*"
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/python-jobs*",
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/sessions*"
     ]
   }

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -165,6 +165,7 @@ data "aws_iam_policy_document" "glue_kms" {
     resources = [
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/crawlers*",
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/jobs*",
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/python-jobs*"
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws-glue/sessions*"
     ]
   }


### PR DESCRIPTION
# Summary
Update the IAM policy to allow the Glue ETL role to use the custom KMS key when writing Python job logs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/646