### PR TITLE
feat: allow Forms Staging to replicate data to Raw

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -38,6 +38,7 @@ data "aws_iam_policy_document" "raw_bucket" {
       identifiers = [
         "arn:aws:iam::659087519042:role/BillingExtractTags",
         "arn:aws:iam::659087519042:role/CostUsageReplicateToDataLake",
+        "arn:aws:iam::687401027353:role/FormsS3ReplicatePlatformDataLake",
         "arn:aws:iam::563894450011:role/SalesforceReplicateToDataLake"
       ]
     }


### PR DESCRIPTION
# Summary
Update the Raw bucket policy to allow S3 to replicate objects to the bucket.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648