### PR TITLE
fix: alarm should only trigger for Freshdesk lambda

### DIFF
--- a/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/alarms.tf
@@ -40,6 +40,10 @@ resource "aws_cloudwatch_metric_alarm" "platform_support_freshdesk_export_errors
   threshold           = "0"
   treat_missing_data  = "notBreaching"
 
+  dimensions = {
+    FunctionName = local.freshdesk_lambda_name
+  }
+
   alarm_actions = [var.sns_topic_alarm_action_arn]
   ok_actions    = [var.sns_topic_ok_action_arn]
 }


### PR DESCRIPTION
# Summary
Update the CloudWatch metric alarm so that it only triggers when the `Errors` metric is from the Freshdesk lambda function.