### PR TITLE
chore: remove the SupersetAthenaReal-all role

### DIFF
--- a/terragrunt/env/root.hcl
+++ b/terragrunt/env/root.hcl
@@ -8,10 +8,8 @@ inputs = {
   env                    = "${local.vars.inputs.env}"
   region                 = "ca-central-1"
   superset_iam_role_arns = [
-    "arn:aws:iam::066023111852:role/SupersetAthenaRead-all",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_support_production",
-    "arn:aws:iam::257394494478:role/SupersetAthenaRead-all",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_gc_forms_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_support_production",


### PR DESCRIPTION
# Summary
This role is no longer required now that we've setup the Superset Meta Database which allows querying across databases.

# Related
- https://github.com/cds-snc/platform-core-services/issues/689