### PR TITLE
fix: remove all references to `all` database

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -33,8 +33,8 @@ data "aws_iam_policy_document" "cross_account_access" {
     ]
     resources = [
       "arn:aws:glue:${var.region}:${var.account_id}:catalog",
-      "arn:aws:glue:${var.region}:${var.account_id}:database/${each.value == "all" ? "*" : each.value}",
-      "arn:aws:glue:${var.region}:${var.account_id}:table/${each.value == "all" ? "*" : each.value}/*",
+      "arn:aws:glue:${var.region}:${var.account_id}:database/${each.value}",
+      "arn:aws:glue:${var.region}:${var.account_id}:table/${each.value}/*",
     ]
   }
 }

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -3,7 +3,6 @@ locals {
   # - arn:aws:iam::123456789012:role/SupersetAthenaRead-datatabase_name
   # The Superset role ARNs are managed by the `superset_iam_role_arns` input variable.
   glue_catalog_databases = [
-    "all", # special case for an IAM role with access to all databases
     aws_glue_catalog_database.operations_aws_production.name,
     aws_glue_catalog_database.platform_gc_forms_production.name,
     aws_glue_catalog_database.platform_support_production.name,


### PR DESCRIPTION
# Summary
As part of the removal of the SupersetAthenaRead-all IAM role, also remove all references to the `all` database.

# Related
- #155 