### PR TITLE
feat: create Forms ETL scheduled job

### DIFF
--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -1,4 +1,63 @@
 #
+# Platform / GC Forms
+#
+data "local_file" "platform_gc_forms_job" {
+  filename = "${path.module}/etl/platform/gc_forms/process_data.py"
+}
+
+resource "aws_s3_object" "platform_gc_forms_job" {
+  bucket = var.glue_bucket_name
+  key    = "platform/gc_forms/process_data.py"
+  source = data.local_file.platform_gc_forms_job.filename
+  etag   = filemd5(data.local_file.platform_gc_forms_job.filename)
+}
+
+resource "aws_glue_job" "platform_gc_forms_job" {
+  name = "Platform / GC Forms"
+
+  glue_version           = "5.0"
+  timeout                = 15 # minutes
+  role_arn               = aws_iam_role.glue_etl.arn
+  security_configuration = aws_glue_security_configuration.encryption_at_rest.name
+  max_capacity           = 1
+
+  command {
+    script_location = "s3://${var.glue_bucket_name}/${aws_s3_object.platform_gc_forms_job.key}"
+    python_version  = "3.9"
+    name            = "pythonshell"
+  }
+
+  default_arguments = {
+    "--continuous-log-logGroup"          = "/aws-glue/python-jobs/${aws_glue_security_configuration.encryption_at_rest.name}/service-role/${aws_iam_role.glue_etl.name}/output"
+    "--continuous-log-logStreamPrefix"   = "platform_gc_forms"
+    "--enable-continuous-cloudwatch-log" = "true"
+    "--enable-continuous-log-filter"     = "true"
+    "--enable-auto-scaling"              = "true"
+    "--enable-job-insights"              = "true"
+    "--enable-metrics"                   = "true"
+    "--enable-observability-metrics"     = "true"
+    "--job-language"                     = "python"
+    "--source_bucket"                    = var.raw_bucket_name
+    "--source_prefix"                    = "platform/gc-forms"
+    "--transformed_bucket"               = var.transformed_bucket_name
+    "--transformed_prefix"               = "platform/gc-forms"
+    "--database_name_raw"                = aws_glue_catalog_database.platform_gc_forms_production_raw.name
+    "--database_name_transformed"        = aws_glue_catalog_database.platform_gc_forms_production.name
+    "--table_name_prefix"                = "platform_gc_forms"
+  }
+}
+
+resource "aws_glue_trigger" "platform_gc_forms_job" {
+  name     = "Platform / GC Forms"
+  schedule = "cron(00 7 * * ? *)" # 7am UTC every day
+  type     = "SCHEDULED"
+
+  actions {
+    job_name = aws_glue_job.platform_gc_forms_job.name
+  }
+}
+
+#
 # Platform / Support / Freshdesk
 #
 data "local_file" "platform_support_freshdesk_job" {

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -49,7 +49,7 @@ resource "aws_glue_job" "platform_gc_forms_job" {
 
 resource "aws_glue_trigger" "platform_gc_forms_job" {
   name     = "Platform / GC Forms"
-  schedule = "cron(00 7 * * ? *)" # 7am UTC every day
+  schedule = "cron(00 2 * * ? *)" # 2am UTC every day
   type     = "SCHEDULED"
 
   actions {


### PR DESCRIPTION
# Summary
Add the ETL job that will process the new Forms data each day.

This includes a change to only read data from the last day and to throw an error if there is no data as the extract should occur everyday.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648