### PR TITLE
fix: add timezone to yesterday

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -117,7 +117,7 @@ def get_new_data(
         logger.info(
             f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3..."
         )
-        yesterday = pd.Timestamp.today() - pd.Timedelta(days=1)
+        yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
         data = wr.s3.read_parquet(
             path=f"s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/",
             use_threads=True,


### PR DESCRIPTION
# Summary
Update the `yesterday` date to include a timezone.  This is required by `awswrangler` when reading the S3 objects.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648