### PR TITLE
fix: switch export functions to arm64

### DIFF
--- a/.github/workflows/docker-apply-production.yml
+++ b/.github/workflows/docker-apply-production.yml
@@ -86,4 +86,15 @@ jobs:
           --image-uri $REGISTRY/${{matrix.lambda}}:${{ env.TAG_VERSION }} > /dev/null 2>&1
         aws lambda wait function-updated \
           --function-name ${{matrix.lambda}}
+
+    - name: Docker generate SBOM
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      env:
+        TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
+      with:
+        docker_image: "$REGISTRY/${{matrix.lambda}}:${{ env.TAG_VERSION }}"
+        dockerfile_path: "./export/${{ matrix.export }}/Dockerfile"
+        platform: "linux/arm64"
+        sbom_name: "${{matrix.lambda}}"
+        token: "${{ secrets.GITHUB_TOKEN }}"
   

--- a/.github/workflows/docker-apply-production.yml
+++ b/.github/workflows/docker-apply-production.yml
@@ -15,7 +15,7 @@ env:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   
 jobs:
   docker-build-push-deploy:

--- a/.github/workflows/docker-apply-production.yml
+++ b/.github/workflows/docker-apply-production.yml
@@ -24,6 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - export: platform/gc_notify
+            lambda: platform-gc-notify-export
           - export: platform/support/freshdesk
             lambda: platform-support-freshdesk-export
 
@@ -46,8 +48,19 @@ jobs:
             - 'export/${{ matrix.export }}/**'
             - '.github/workflows/docker-apply-production.yml'
 
+    - name: Exit if no changes
+      if: steps.changes.outputs.export == 'false'
+      run: |
+        echo "No changes to test"
+        exit 0
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
     - name: Configure AWS credentials using OIDC
-      if: steps.changes.outputs.export == 'true'
       uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
       with:
         role-to-assume: arn:aws:iam::739275439843:role/data-lake-apply
@@ -55,11 +68,9 @@ jobs:
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR
-      if: steps.changes.outputs.export == 'true'
       uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
     - name: Build and push Docker image to Amazon ECR
-      if: steps.changes.outputs.export == 'true'
       working-directory: ./export/${{ matrix.export }}
       run: |
         make docker
@@ -69,7 +80,6 @@ jobs:
         docker push $REGISTRY/${{matrix.lambda}}:latest
 
     - name: Update Lambda Docker image
-      if: steps.changes.outputs.export == 'true'
       run: |
         aws lambda update-function-code \
           --function-name ${{matrix.lambda}} \

--- a/.github/workflows/export-pull-request.yml
+++ b/.github/workflows/export-pull-request.yml
@@ -48,6 +48,12 @@ jobs:
           echo "No changes to test"
           exit 0
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+  
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+  
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:

--- a/export/platform/gc_notify/Dockerfile
+++ b/export/platform/gc_notify/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13@sha256:2cb6ce5433f8ae6ddb114eeabc7b68c89b19017a57849f4e077a0cd3585e4e8c
+FROM public.ecr.aws/lambda/python:3.13@sha256:b281081b54f2b2df0ec1144ca128678fd0d4203eda3ee987c35e8bb64095b014
 
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 COPY main.py ${LAMBDA_TASK_ROOT}

--- a/export/platform/gc_notify/Makefile
+++ b/export/platform/gc_notify/Makefile
@@ -1,5 +1,5 @@
 docker:
-	docker build --platform linux/amd64 --tag platform-gc-notify-export .
+	docker build --platform linux/arm64 --tag platform-gc-notify-export .
  
 fmt:
 	black . $(ARGS)

--- a/export/platform/support/freshdesk/Dockerfile
+++ b/export/platform/support/freshdesk/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13@sha256:2cb6ce5433f8ae6ddb114eeabc7b68c89b19017a57849f4e077a0cd3585e4e8c
+FROM public.ecr.aws/lambda/python:3.13@sha256:b281081b54f2b2df0ec1144ca128678fd0d4203eda3ee987c35e8bb64095b014
 
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 COPY main.py ${LAMBDA_TASK_ROOT}

--- a/export/platform/support/freshdesk/Makefile
+++ b/export/platform/support/freshdesk/Makefile
@@ -1,5 +1,5 @@
 docker:
-	docker build --platform linux/amd64 --tag platform-support-freshdesk-export .
+	docker build --platform linux/arm64 --tag platform-support-freshdesk-export .
  
 fmt:
 	black . $(ARGS)

--- a/terragrunt/aws/export/platform/gc_notify/lambda.tf
+++ b/terragrunt/aws/export/platform/gc_notify/lambda.tf
@@ -2,11 +2,12 @@
 # GC Notify RDS snapshot exports to the Data Lake's Raw bucket
 #
 module "platform_gc_notify_export" {
-  source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.4.0"
+  source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.4.1"
 
   lambda_name                = local.gc_notify_lambda_name
   lambda_schedule_expression = "cron(0 8 ? * 1 *)" # Weekly, Monday at 8am UTC for testing
   lambda_timeout             = "60"
+  lambda_architectures       = ["arm64"]
 
   lambda_policies = [
     data.aws_iam_policy_document.platform_gc_notify_export.json

--- a/terragrunt/aws/export/platform/support/freshdesk/lambda.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/lambda.tf
@@ -2,11 +2,12 @@
 # Freshdesk export via a scheduled Lambda function
 #
 module "platform_support_freshdesk_export" {
-  source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.3.2"
+  source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.4.1"
 
   lambda_name                = local.freshdesk_lambda_name
   lambda_schedule_expression = "cron(0 5 * * ? *)" # 5am UTC every day
   lambda_timeout             = "300"
+  lambda_architectures       = ["arm64"]
   s3_arn_write_path          = "${var.raw_bucket_arn}/${local.freshdesk_export_path}/*"
 
   lambda_policies = [


### PR DESCRIPTION
# Summary 
Switch the Lambda function architecture for the export functions to `arm64`.  This change is being made as it is more performant and cheaper.