### PR TITLE
feat: publish ETL CloudWatch metrics for GC Forms

### DIFF
--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -90,7 +90,8 @@ data "aws_iam_policy_document" "glue_etl_combined" {
   source_policy_documents = [
     data.aws_iam_policy_document.s3_read_data_lake.json,
     data.aws_iam_policy_document.s3_write_data_lake.json,
-    data.aws_iam_policy_document.glue_kms.json
+    data.aws_iam_policy_document.glue_kms.json,
+    data.aws_iam_policy_document.cloudwatch_put_metrics.json
   ]
 }
 
@@ -182,6 +183,19 @@ data "aws_iam_policy_document" "s3_write_data_lake" {
       "${var.curated_bucket_arn}/*",
       "${var.transformed_bucket_arn}/*",
       "${var.raw_bucket_arn}/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_put_metrics" {
+  statement {
+    sid    = "PutCloudWatchMetrics"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData"
+    ]
+    resources = [
+      "*" # Only wildcard is allowed for this action
     ]
   }
 }


### PR DESCRIPTION
# Summary
Publish CloudWatch metrics for the GC Forms dataset processing.  These metrics will then be used to perform anomaly detection to ensure the ETL is processing the expected amount of data.

This change also includes the IAM policy update required to allow the ETL role to publish metric data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/691