### PR TITLE
fix: update Forms ETL to maintain time series nature of data

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -104,13 +104,11 @@ def is_type_compatible(series: pd.Series, glue_type: str) -> bool:
 def get_new_data(
     path: str,
     date_columns: List[str],
-    sort_columns: List[str],
     partition_created_column: str = None,
 ) -> pd.DataFrame:
     """
     Reads the data from the specified path in S3 and returns a DataFrame.
-    This method is responsible for ensuring the data types are correct and
-    that only the most recent duplicate items are kept.
+    This method is responsible for ensuring the data types are correct.
 
     To limit unnecessary data processing, the data is filtered to only include
     items that have been modified in the last 24 hours.
@@ -134,50 +132,12 @@ def get_new_data(
             data[date_column] = pd.to_datetime(data[date_column], errors="coerce")
             data[date_column] = data[date_column].dt.tz_localize(None)
 
-        # Sort data by specified columns ascending, except for the timestamp column
-        # which we sort descending.  This groups all duplicate items and allows us
-        # to keep only the most recent duplicate.
-        if sort_columns:
-            data = data.sort_values(
-                by=sort_columns + ["timestamp"],
-                ascending=[True] * len(sort_columns) + [False],
-            )
-            data = data.drop_duplicates(subset=sort_columns, keep="first")
-
         if partition_created_column:
             data["month"] = data[partition_created_column].dt.strftime("%Y-%m")
 
     except wr.exceptions.NoFilesFound:
         logger.error(f"No new {path} data found.")
     return data
-
-
-def remove_old_data(path: str, table: str, partition_cols: List[str]):
-    """
-    Remove transformed data that was not exported today
-    """
-    data = wr.s3.read_parquet(
-        path=f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}/{path}/",
-        use_threads=True,
-        dataset=True,
-    )
-    yesterday = pd.Timestamp.today() - pd.Timedelta(days=1)
-    data = data[data["timestamp"] > yesterday]
-
-    # Check if there is any data left to save.  This is a safety mechanism to avoid
-    # removing all data if the Forms data sync fails.
-    if data.empty:
-        logger.error(f"No new {path} data found after pruning.")
-    else:
-        wr.s3.to_parquet(
-            df=data,
-            path=f"{TRANSFORMED_PATH}/{path}/",
-            dataset=True,
-            mode="overwrite_partitions",
-            database=DATABASE_NAME_TRANSFORMED,
-            table=table,
-            partition_cols=partition_cols,
-        )
 
 
 def publish_metric(cloudwatch, dataset_name, count, processing_time):
@@ -218,10 +178,8 @@ def process_data():
         {
             "path": "historical-data",
             "date_columns": ["date"],
-            "sort_columns": None,
             "partition_created_column": "date",
             "partition_columns": ["month"],
-            "prune_old_data": False,
         },
         {
             "path": "processed-data/template",
@@ -233,26 +191,20 @@ def process_data():
                 "created_at",
                 "updated_at",
             ],
-            "sort_columns": ["id"],
             "partition_created_column": "created_at",
             "partition_columns": ["month"],
-            "prune_old_data": True,
         },
         {
             "path": "processed-data/templateToUser",
             "date_columns": ["timestamp"],
-            "sort_columns": ["templateid", "userid"],
             "partition_created_column": None,
             "partition_columns": None,
-            "prune_old_data": True,
         },
         {
             "path": "processed-data/user",
             "date_columns": ["emailverified", "lastlogin", "createdat", "timestamp"],
-            "sort_columns": ["id"],
             "partition_created_column": "lastlogin",  # User created date is currently in this field
             "partition_columns": ["month"],
-            "prune_old_data": True,
         },
     ]
     cloudwatch = boto3.client("cloudwatch")
@@ -269,7 +221,6 @@ def process_data():
         data = get_new_data(
             path,
             dataset.get("date_columns"),
-            dataset.get("sort_columns"),
             dataset.get("partition_created_column"),
         )
         if not data.empty:
@@ -297,12 +248,6 @@ def process_data():
                 table=table,
                 partition_cols=partition_cols,
             )
-
-            # Remove transformed data that does not have a `timestamp` from today
-            # TODO: Better way to do this that does not involve reading all Transformed data
-            if dataset.get("prune_old_data"):
-                logger.info(f"Removing old {path} data...")
-                remove_old_data(path, table, partition_cols)
 
         else:
             logger.info(f"No new {path} data found.")


### PR DESCRIPTION
# Summary
The Forms team would like to be able to plot trends over time in their data, so they are expecting to have each night's export available with its `timestamp` column.

# Related
 -https://github.com/cds-snc/platform-core-services/issues/648