### PR TITLE
feat: add Glue crawler and databases for Notify data

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -49,6 +49,34 @@ resource "aws_glue_crawler" "platform_gc_forms_templates_production_raw" {
 }
 
 #
+# Platform / GC Notify
+#
+resource "aws_glue_crawler" "platform_gc_notify_production_raw" {
+  name          = "Platform / GC Notify"
+  description   = "Classify the raw GC Notify data"
+  database_name = aws_glue_catalog_database.platform_gc_notify_production_raw.name
+  table_prefix  = "platform_gc_notify_raw_"
+
+  role                   = aws_iam_role.glue_crawler.arn
+  security_configuration = aws_glue_security_configuration.encryption_at_rest.name
+
+  s3_target {
+    path = "s3://${var.raw_bucket_name}/platform/gc-notify"
+  }
+
+  configuration = jsonencode(
+    {
+      CrawlerOutput = {
+        Tables = {
+          TableThreshold = 14
+        }
+      }
+      CreatePartitionIndex = true
+      Version              = 1
+  })
+}
+
+#
 # Platform / Support / Freshdesk
 #
 resource "aws_glue_crawler" "platform_support_freshdesk_production" {

--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -8,6 +8,16 @@ resource "aws_glue_catalog_database" "platform_gc_forms_production_raw" {
   description = "RAW: data source path: /platform/gc-forms/*"
 }
 
+resource "aws_glue_catalog_database" "platform_gc_notify_production" {
+  name        = "platform_gc_notify_production"
+  description = "TRANSFORMED: data source path: /platform/gc-notify/*"
+}
+
+resource "aws_glue_catalog_database" "platform_gc_notify_production_raw" {
+  name        = "platform_gc_notify_production_raw"
+  description = "RAW: data source path: /platform/gc-notify/*"
+}
+
 resource "aws_glue_catalog_database" "platform_support_production" {
   name        = "platform_support_production"
   description = "TRANSFORMED: data source path: /platform/support/*"


### PR DESCRIPTION
# Summary
Add the crawler and databases that will be used to classify and hold the data schema.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668