### PR TITLE
fix: Notify Glue crawler to handle dynamic source path

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/kms.tf
+++ b/terragrunt/aws/export/platform/gc_notify/kms.tf
@@ -45,5 +45,10 @@ data "aws_iam_policy_document" "platform_notify_rds_snapshot_exports_kms" {
       type        = "AWS"
       identifiers = [local.gc_notify_rds_export_role_arn]
     }
+
+    principals {
+      type        = "Service"
+      identifiers = ["glue.amazonaws.com"]
+    }
   }
 }

--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -61,7 +61,8 @@ resource "aws_glue_crawler" "platform_gc_notify_production_raw" {
   security_configuration = aws_glue_security_configuration.encryption_at_rest.name
 
   s3_target {
-    path = "s3://${var.raw_bucket_name}/platform/gc-notify"
+    path       = "s3://${var.raw_bucket_name}/platform/gc-notify"
+    exclusions = ["**/*.json"]
   }
 
   configuration = jsonencode(
@@ -71,8 +72,11 @@ resource "aws_glue_crawler" "platform_gc_notify_production_raw" {
           TableThreshold = 14
         }
       }
+      Grouping = {
+        TableLevelConfiguration = 4
+      }
       CreatePartitionIndex = true
-      Version              = 1
+      Version              = 1.0
   })
 }
 

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -51,6 +51,7 @@ resource "aws_glue_trigger" "platform_gc_forms_job" {
   name     = "Platform / GC Forms"
   schedule = "cron(00 2 * * ? *)" # 2am UTC every day
   type     = "SCHEDULED"
+  enabled  = false
 
   actions {
     job_name = aws_glue_job.platform_gc_forms_job.name


### PR DESCRIPTION
# Summary
Update the Notify Glue crawler so that it can adapt to the dynamically updating source path each day.  This is required since RDS snapshot to S3 automatically prefixes the export with the export's unique name.

Also updates the IAM permissions of the Glue roles to allow them to use the Notify RDS export KMS key.

⚠️  These changes were applied locally during testing.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668