### PR TITLE
fix: remove Notify Glue crawler

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -49,38 +49,6 @@ resource "aws_glue_crawler" "platform_gc_forms_templates_production_raw" {
 }
 
 #
-# Platform / GC Notify
-#
-resource "aws_glue_crawler" "platform_gc_notify_production_raw" {
-  name          = "Platform / GC Notify"
-  description   = "Classify the raw GC Notify data"
-  database_name = aws_glue_catalog_database.platform_gc_notify_production_raw.name
-  table_prefix  = "platform_gc_notify_raw_"
-
-  role                   = aws_iam_role.glue_crawler.arn
-  security_configuration = aws_glue_security_configuration.encryption_at_rest.name
-
-  s3_target {
-    path       = "s3://${var.raw_bucket_name}/platform/gc-notify"
-    exclusions = ["**/*.json"]
-  }
-
-  configuration = jsonencode(
-    {
-      CrawlerOutput = {
-        Tables = {
-          TableThreshold = 14
-        }
-      }
-      Grouping = {
-        TableLevelConfiguration = 4
-      }
-      CreatePartitionIndex = true
-      Version              = 1.0
-  })
-}
-
-#
 # Platform / Support / Freshdesk
 #
 resource "aws_glue_crawler" "platform_support_freshdesk_production" {

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -57,8 +57,7 @@ resource "aws_iam_policy" "glue_crawler" {
 data "aws_iam_policy_document" "glue_crawler_combined" {
   source_policy_documents = [
     data.aws_iam_policy_document.s3_read_data_lake.json,
-    data.aws_iam_policy_document.glue_kms.json,
-    data.aws_iam_policy_document.gc_notify_rds_export_kms.json
+    data.aws_iam_policy_document.glue_kms.json
   ]
 }
 


### PR DESCRIPTION
# Summary
After chatting with the team, we've found a better way to handle this by just reading the parquet directly and then validating with the know types of each field.

This approach removes the need to have to deal with the dynamic crawl path for each RDS snapshot export.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668