### PR TITLE
feat: add the Notify Glue ETL job

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -12,14 +12,27 @@ import boto3
 import pandas as pd
 import pyarrow.dataset as ds
 
+from awsglue.utils import getResolvedOptions
 
-SOURCE_BUCKET = "cds-data-lake-raw-production"
-SOURCE_PREFIX = "platform/gc-notify"
-TRANSFORMED_BUCKET = "cds-data-lake-transformed-production"
-TRANSFORMED_PREFIX = "platform/gc-notify"
+args = getResolvedOptions(
+    sys.argv,
+    [
+        "source_bucket",
+        "source_prefix",
+        "transformed_bucket",
+        "transformed_prefix",
+        "database_name_transformed",
+        "table_name_prefix",
+    ],
+)
+
+SOURCE_BUCKET = args["source_bucket"]
+SOURCE_PREFIX = args["source_prefix"]
+TRANSFORMED_BUCKET = args["transformed_bucket"]
+TRANSFORMED_PREFIX = args["transformed_prefix"]
 TRANSFORMED_PATH = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}"
-DATABASE_NAME_TRANSFORMED = "platform_gc_notify_production"
-TABLE_NAME_PREFIX = "platform_gc_notify"
+DATABASE_NAME_TRANSFORMED = args["database_name_transformed"]
+TABLE_NAME_PREFIX = args["table_name_prefix"]
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/terragrunt/env/production/glue/.terraform.lock.hcl
+++ b/terragrunt/env/production/glue/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:aTsKLhA0m6ZW560baooNkF1t47TZvpBvaoPEI8wQpDo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.93.0"
   constraints = "~> 5.0"


### PR DESCRIPTION
# Summary
Add the Glue ETL `pythonshell` job that will process the Notify RDS snapshot exports.