### PR TITLE
feat: add CloudWatch `ERROR` metric alarm for ETL logs

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -31,6 +31,39 @@ resource "aws_cloudwatch_metric_alarm" "glue_crawler_error" {
   ok_actions    = [aws_sns_topic.cloudwatch_ok_action.arn]
 }
 
+#
+# Glue ETL errors
+#
+resource "aws_cloudwatch_log_metric_filter" "glue_etl_error" {
+  name           = "glue-etl-error"
+  pattern        = local.glue_etl_metric_filter_error_pattern
+  log_group_name = "${var.glue_etl_log_group_name}/output"
+
+  metric_transformation {
+    name          = local.glue_etl_error_metric_name
+    namespace     = local.data_lake_namespace
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "glue_etl_error" {
+  alarm_name          = "glue-etl-error"
+  alarm_description   = "Errors logged over 1 minute by a Glue ETL job."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.glue_etl_error.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.glue_etl_error.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alarm_action.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_ok_action.arn]
+}
+
 resource "aws_cloudwatch_metric_alarm" "glue_job_failures" {
   alarm_name          = "glue-job-failures"
   alarm_description   = "Glue Job state has changed to `Failure`, `Timeout` or `Error`."

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -2,4 +2,6 @@ locals {
   data_lake_namespace                      = "data-lake"
   glue_crawler_metric_filter_error_pattern = "ERROR"
   glue_crawler_error_metric_name           = "glue-crawler-error"
+  glue_etl_metric_filter_error_pattern     = "ERROR"
+  glue_etl_error_metric_name               = "glue-etl-error"
 }

--- a/terragrunt/aws/alarms/variables.tf
+++ b/terragrunt/aws/alarms/variables.tf
@@ -8,3 +8,8 @@ variable "glue_crawler_log_group_name" {
   description = "The name of the Glue Crawler CloudWatch log group."
   type        = string
 }
+
+variable "glue_etl_log_group_name" {
+  description = "The name of the Glue ETL CloudWatch log group."
+  type        = string
+}

--- a/terragrunt/aws/glue/outputs.tf
+++ b/terragrunt/aws/glue/outputs.tf
@@ -2,3 +2,8 @@ output "glue_crawler_log_group_name" {
   description = "The name of the Glue Crawler CloudWatch log group."
   value       = local.glue_crawler_log_group_name
 }
+
+output "glue_etl_log_group_name" {
+  description = "The name of the Glue ETL CloudWatch log group."
+  value       = local.glue_etl_log_group_name
+}

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -12,11 +12,13 @@ dependency "glue" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
     glue_crawler_log_group_name = "mock-glue-crawler-log-group"
+    glue_etl_log_group_name     = "mock-glue-etl-log-group"
   }
 }
 
 inputs = {
   glue_crawler_log_group_name = dependency.glue.outputs.glue_crawler_log_group_name
+  glue_etl_log_group_name     = dependency.glue.outputs.glue_etl_log_group_name
 }
 
 include {


### PR DESCRIPTION
# Summary
Add a new CloudWatch alarm and `ERROR` metric to catch errors logged by the ETL jobs.  Currently we only have an alarm when the job's state is reported as error.  This will allow us to have finer grained error alarms.
