### PR TITLE
fix: remove Notify data with null partition columns

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/initial_load.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/initial_load.py
@@ -121,7 +121,6 @@ def load_data(
                 batch_size=100000, columns=field_names
             ):
                 data = pa.Table.from_batches([batch]).to_pandas()
-                rows += len(data)
 
                 # Process timestamps
                 for field in fields:
@@ -136,6 +135,9 @@ def load_data(
 
                 # Define partition columns
                 if partition_timestamp and partition_cols:
+                    # Remove rows if they do not have the partition_timestamp column
+                    data = data[~data[partition_timestamp].isna()]
+
                     partition_format = {
                         "day": "%Y-%m-%d",
                         "month": "%Y-%m",
@@ -164,6 +166,7 @@ def load_data(
                     partition_cols=partition_cols,
                     existing_data_behavior="overwrite_or_ignore",
                 )
+                rows += len(data)
 
         return rows
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
@@ -2,6 +2,7 @@
   "table_name": "notification_history",
   "partition_timestamp": "created_at",
   "partition_cols": ["year", "month"],
+  "incremental_load": true,
   "fields": [
     {
       "name": "id",


### PR DESCRIPTION
# Summary
Update the initial load and ETL script to remove Notify data that has a NULL partition column.

Update the ETL to properly handle the incremental load case for the `notification_history` table.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668