### PR TITLE
feat: enable Forms ETL schedule

### DIFF
--- a/docs/data/catalog/platform/gc-forms/templates.md
+++ b/docs/data/catalog/platform/gc-forms/templates.md
@@ -1,10 +1,5 @@
 # Platform / GC Forms / Templates
 
-### :warning: Note
-This dataset is still in testing and only a snapshot of Staging data is available in Superset. 
-
----
-
 Dataset providing GC Forms template data.  There are 4 tables as part of this dataset:
 
 - `historical_data`: one-time snapshot of published form data that was previously managed in an external source.
@@ -60,7 +55,7 @@ Here's a descriptive list of the fields in each table:
 | metric_format__from_metric_ | string | Format of the metric field (always "Number") |
 | unit_of_measurement | string | Unit used for measuring the metric |
 | department | string | Government department associated with the form |
-| client_email | string | Email address of the client who owns the form |
+| client_email | string | Email address domain of the client who owns the form |
 | number_value | string | Numerical value of the metric (always "1") |
 | security_classification | string | Security classification of the form data (Protected A, Protected B, Unclassified) |
 | comment | string | Additional comments about the record |
@@ -122,8 +117,7 @@ Here's a descriptive list of the fields in each table:
 | Field | Type | Description |
 |-------|------|-------------|
 | id | string | Unique identifier for the user |
-| name | string | User's full name |
-| email | string | User's Government of Canada email address |
+| email | string | User's Government of Canada email address domain |
 | emailverified | timestamp | When the user's email was verified |
 | lastlogin | timestamp | Time of user's most recent login |
 | active | boolean | Indicates whether the user account is active |

--- a/docs/data/pipelines/platform/gc-forms/templates.md
+++ b/docs/data/pipelines/platform/gc-forms/templates.md
@@ -1,10 +1,5 @@
 # Platform / GC Forms / Templates
 
-### :warning: Note
-This dataset is still in testing and only a snapshot of Staging data is available in Superset. 
-
----
-
 ## Description
 The GC Forms `Templates` dataset provides information on form templates, and the users that own them, in [Parquet format](https://parquet.apache.org/). The role of the form template is to control how the rendered form is presented to users for submission.
 

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -51,7 +51,6 @@ resource "aws_glue_trigger" "platform_gc_forms_job" {
   name     = "Platform / GC Forms"
   schedule = "cron(00 2 * * ? *)" # 2am UTC every day
   type     = "SCHEDULED"
-  enabled  = false
 
   actions {
     job_name = aws_glue_job.platform_gc_forms_job.name

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -123,10 +123,10 @@ def get_new_data(
     """
     data = pd.DataFrame()
     try:
-        logger.info(
-            f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3..."
-        )
         yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
+        logger.info(
+            f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3 from {yesterday}..."
+        )
         data = wr.s3.read_parquet(
             path=f"s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/",
             use_threads=True,


### PR DESCRIPTION
# Summary
Update the Forms ETL to run on its nightly schedule.  Also adds date logging to show which S3 files are being read by the job.

Also updates the data docs with the latest changes.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648