### PR TITLE
chore: disable Forms crawler

### DIFF
--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -44,8 +44,6 @@ resource "aws_glue_crawler" "platform_gc_forms_templates_production_raw" {
       CreatePartitionIndex = true
       Version              = 1
   })
-
-  schedule = "cron(00 6 * * ? *)" # 6am UTC check for schema changes
 }
 
 #


### PR DESCRIPTION
# Summary
Disable the scheduled Forms schema crawler now that we have finalized the schema.  This will allow us to catch unexpected schema changes in the daily ETL runs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648