### PR TITLE
fix: Notify initial load infer date

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/initial_load.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/initial_load.py
@@ -128,7 +128,6 @@ def load_data(
                         date_column = field["name"]
                         data[date_column] = pd.to_datetime(
                             data[date_column],
-                            format="%Y-%m-%d %H:%M:%S.%f",
                             errors="coerce",
                         )
                         data[date_column] = data[date_column].dt.tz_localize(None)


### PR DESCRIPTION
# Summary
Update the initial load script to determine the date format automatically rather than setting a fixed format.

This handles cases where the timestamps do not have millisecond precision in the exported data (Notify test data):
```
YYYY-MM-DD HH:MM:SS.mmmmmm
YYYY-MM-DD HH:MM:SS
```

# Related
- https://github.com/cds-snc/platform-core-services/issues/668