### PR TITLE
fix: update the list of Glue catalog databases

### DIFF
--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -5,6 +5,7 @@ locals {
   glue_catalog_databases = [
     aws_glue_catalog_database.operations_aws_production.name,
     aws_glue_catalog_database.platform_gc_forms_production.name,
+    aws_glue_catalog_database.platform_gc_notify_production.name,
     aws_glue_catalog_database.platform_support_production.name,
     aws_glue_catalog_database.bes_crm_salesforce_production.name,
   ]


### PR DESCRIPTION
# Summary
Add the GC Notify database to the list of Glue catalog databases that can be accessed by Superset.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668