### PR TITLE
fix: Notify export needs full key ARN

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/lambda.tf
+++ b/terragrunt/aws/export/platform/gc_notify/lambda.tf
@@ -16,7 +16,7 @@ module "platform_gc_notify_export" {
   lambda_environment_variables = {
     DB_CLUSTER_IDENTIFIER = "notification-canada-ca-${local.gc_notify_env}-cluster"
     IAM_ROLE_ARN          = local.gc_notify_rds_export_role_arn
-    KMS_KEY_ID            = aws_kms_key.platform_notify_rds_snapshot_exports.key_id
+    KMS_KEY_ID            = aws_kms_key.platform_notify_rds_snapshot_exports.arn
     TABLE_SCHEMA          = "NotificationCanadaCa${local.gc_notify_env}.public"
     S3_BUCKET_NAME        = var.raw_bucket_name
     S3_EXPORT_PREFIX      = "platform/gc-notify"


### PR DESCRIPTION
# Summary
Update the Notify export Lambda env var to include the fule KMS key ARN.  This is required for the cross-account invoke of the RDS snapshot export to work.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668