### PR TITLE
feat: auto-delete previous Notify data exports

### DIFF
--- a/terragrunt/aws/buckets/locals.tf
+++ b/terragrunt/aws/buckets/locals.tf
@@ -7,6 +7,15 @@ locals {
       days = "30"
     }
   }
+  # GC Notify expire old export data
+  lifecycle_expire_gc_notify = {
+    id      = "expire_gc_notify"
+    enabled = true
+    prefix  = "platform/gc-notify/"
+    expiration = {
+      days = "1"
+    }
+  }
   # Cleanup old versions and incomplete uploads
   lifecycle_remove_noncurrent_versions = {
     id                                     = "remove_noncurrent_versions"

--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -13,7 +13,8 @@ module "raw_bucket" {
 
   lifecycle_rule = [
     local.lifecycle_remove_noncurrent_versions,
-    local.lifecycle_transition_storage
+    local.lifecycle_transition_storage,
+    local.lifecycle_expire_gc_notify
   ]
 
   versioning = {


### PR DESCRIPTION
# Summary
Add an S3 lifecycle rule to the Raw bucket that automatically deletes exported data that is more than 1 day old.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668