### PR TITLE
feat: add Superset Prod IAM role for Forms data

### DIFF
--- a/terragrunt/env/root.hcl
+++ b/terragrunt/env/root.hcl
@@ -9,6 +9,7 @@ inputs = {
   region                 = "ca-central-1"
   superset_iam_role_arns = [
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-operations_aws_production",
+    "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_gc_forms_production",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_support_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_gc_forms_production",


### PR DESCRIPTION
# Summary
Add the IAM role that will be used by Superset Prod to access Forms Prod data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648