### PR TITLE
fix: Notify ETL to enforce data types

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/initial_load.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/initial_load.py
@@ -85,7 +85,7 @@ def postgres_to_pandas_type(field_type: str) -> str:
         "boolean": pd.BooleanDtype(),
         "timestamp": "datetime64[ns]",
     }
-    return postgres_to_pandas.get(field_type, field_type)
+    return postgres_to_pandas.get(field_type)
 
 
 def is_type_compatible(series: pd.Series, field_type: str) -> bool:
@@ -94,7 +94,7 @@ def is_type_compatible(series: pd.Series, field_type: str) -> bool:
     """
     expected_type = postgres_to_pandas_type(field_type)
     if expected_type is None:
-        logger.error(f"Unknown Glue type '{field_type}' for validation.")
+        logger.error(f"Unknown Postgres type '{field_type}' for validation.")
         return False
     try:
         series.astype(expected_type)

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -83,7 +83,7 @@ def validate_schema(
     return True
 
 
-def postgres_to_pandas_type(field_type: str) -> str:
+def postgres_to_pandas_type(field_type: str) -> str | None:
     """
     Convert PostgreSQL data types to pandas data types.
     """
@@ -105,7 +105,7 @@ def postgres_to_pandas_type(field_type: str) -> str:
         "boolean": pd.BooleanDtype(),
         "timestamp": "datetime64[ns]",
     }
-    return postgres_to_pandas.get(field_type, field_type)
+    return postgres_to_pandas.get(field_type)
 
 
 def is_type_compatible(series: pd.Series, field_type: str) -> bool:
@@ -114,7 +114,7 @@ def is_type_compatible(series: pd.Series, field_type: str) -> bool:
     """
     expected_type = postgres_to_pandas_type(field_type)
     if expected_type is None:
-        logger.error(f"Unknown Glue type '{field_type}' for validation.")
+        logger.error(f"Unknown Postgres type '{field_type}' for validation.")
         return False
     try:
         series.astype(expected_type)

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -31,8 +31,8 @@ args = getResolvedOptions(
 # Specifies the defautal date to start and end the incremental load from
 # which is all of yesterday's data
 today = pd.Timestamp.now().normalize()
-YESTERDAY_MIDNIGHT = (today - pd.Timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S.%f")
-TODAY_MIDNIGHT = today.strftime("%Y-%m-%d %H:%M:%S.%f")
+YESTERDAY_MIDNIGHT = (today - pd.Timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+TODAY_MIDNIGHT = today.strftime("%Y-%m-%d %H:%M:%S")
 INCREMENTAL_DATE_FROM = args.get("incremental_date_from", YESTERDAY_MIDNIGHT)
 INCREMENTAL_DATE_TO = args.get("incremental_date_to", TODAY_MIDNIGHT)
 
@@ -146,13 +146,11 @@ def get_new_data(
 
         # Only get new data within the time range
         if date_from and date_to and partition_timestamp:
-            date_from = pd.Timestamp(date_from)
-            date_to = pd.Timestamp(date_to)
             logger.info(f"Incremental data load from {date_from} to {date_to}...")
             dataset = ds.dataset(s3_path, format="parquet")
-            filter_expr = (
-                ds.field(partition_timestamp).cast("timestamp[ns]") >= date_from
-            ) & (ds.field(partition_timestamp).cast("timestamp[ns]") < date_to)
+            filter_expr = (ds.field(partition_timestamp) >= date_from) & (
+                ds.field(partition_timestamp) < date_to
+            )
             scanner = dataset.scanner(filter=filter_expr, columns=field_names)
             table = scanner.to_table()
             data = table.to_pandas()

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -32,7 +32,7 @@ args = getResolvedOptions(
 # which is all of yesterday's data
 today = pd.Timestamp.now().normalize()
 YESTERDAY_MIDNIGHT = (today - pd.Timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S.%f")
-TODAY_MIDNIGHT = today.strftime.strftime("%Y-%m-%d %H:%M:%S.%f")
+TODAY_MIDNIGHT = today.strftime("%Y-%m-%d %H:%M:%S.%f")
 INCREMENTAL_DATE_FROM = args.get("incremental_date_from", YESTERDAY_MIDNIGHT)
 INCREMENTAL_DATE_TO = args.get("incremental_date_to", TODAY_MIDNIGHT)
 


### PR DESCRIPTION
# Summary
Update the Notify ETL so that the data types are exported data are enforced and the incremental load only pulls yesterday's range of data.

Also prevent the Glue schema from being updated as new data is written.  This will cause an error to be thrown if data has an unexpected data type.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668