### PR TITLE
fix: perform incremental loads at the partition level

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -292,7 +292,7 @@ def get_incremental_load_date_from(data_retention_days: int) -> pd.Timestamp:
     all data within the overwritten month partition(s) while respecting the data retention policy.
     """
     today = pd.Timestamp.now().normalize()
-    month_start = today - pd.DateOffset(days=data_retention_days).replace(day=1)
+    month_start = (today - pd.DateOffset(days=data_retention_days)).replace(day=1)
     return month_start
 
 
@@ -319,7 +319,7 @@ def process_data():
         incremental_load = dataset.get("incremental_load", False)
         retention_days = dataset.get("retention_days", 0)
 
-        # Retreive the new data
+        # Retrieve the new data
         logger.info(f"Processing {table_name} data...")
         data = get_new_data(
             path,

--- a/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
@@ -3,6 +3,7 @@
   "partition_timestamp": "created_at",
   "partition_cols": ["year", "month"],
   "incremental_load": true,
+  "retention_days": 7,
   "fields": [
     {
       "name": "id",


### PR DESCRIPTION
# Summary
Update the incremental load logic so that it considers the data retention period and loads the full partition(s) required to refresh the historical notification data each day.

This is required because of how the `notification_history` table is refreshed by its nightly job.

## Examples
### One partition reloaded
- `Current date`: April 10
- `Retention period`: 7 days
- `Reload from`: April 10 - 7 days = April 3
- `Reload partition`: April

### Two partitions reloaded
- `Current date`: April 3
- `Retention period`: 7 days
- `Reload from`: April 3 - 7 days = March 27
- `Reload partitions`: March and April

# Related
- https://github.com/cds-snc/platform-core-services/issues/668