### PR TITLE
fix: Notify month start should be a string

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -284,7 +284,7 @@ def download_s3_object(s3, s3_url, filename):
     )
 
 
-def get_incremental_load_date_from(data_retention_days: int) -> pd.Timestamp:
+def get_incremental_load_date_from(data_retention_days: int) -> str:
     """
     Get the date from which to load incremental data.  This will always be the beginning of
     the month that is today minus the retention days.  The reason for this is because we
@@ -293,7 +293,7 @@ def get_incremental_load_date_from(data_retention_days: int) -> pd.Timestamp:
     """
     today = pd.Timestamp.now().normalize()
     month_start = (today - pd.DateOffset(days=data_retention_days)).replace(day=1)
-    return month_start
+    return month_start.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def process_data():


### PR DESCRIPTION
# Summary
Update the incremental load date to be a string.  This allows it to be compared to the VARCHAR dates in the RDS data export.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668