### PR TITLE
feat: enable Notify export and ETL schedule

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/lambda.tf
+++ b/terragrunt/aws/export/platform/gc_notify/lambda.tf
@@ -5,7 +5,7 @@ module "platform_gc_notify_export" {
   source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.4.1"
 
   lambda_name                = local.gc_notify_lambda_name
-  lambda_schedule_expression = "cron(0 8 ? * 1 *)" # Weekly, Monday at 8am UTC for testing
+  lambda_schedule_expression = "cron(0 4 ? * * *)" # Daily at 4am UTC
   lambda_timeout             = "60"
   lambda_architectures       = ["arm64"]
 

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -119,6 +119,16 @@ resource "aws_glue_job" "platform_gc_notify_job" {
   }
 }
 
+resource "aws_glue_trigger" "platform_gc_notify_job" {
+  name     = "Platform / GC Notify"
+  schedule = "cron(0 5 * * ? *)" # Daily at 5am UTC
+  type     = "SCHEDULED"
+
+  actions {
+    job_name = aws_glue_job.platform_gc_notify_job.name
+  }
+}
+
 #
 # Platform / Support / Freshdesk
 #


### PR DESCRIPTION
# Summary 
Setup the Notify export and ETL schedules to run each day.  This will let us confirm that the automated process works correctly in Staging before switching to the Prod datasource.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668