### PR TITLE
feat: switch to export Notify prod data

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/locals.tf
+++ b/terragrunt/aws/export/platform/gc_notify/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  gc_notify_env                 = "staging"
+  gc_notify_env                 = "production"
   gc_notify_lambda_name         = "platform-gc-notify-export"
-  gc_notify_rds_export_role_arn = "arn:aws:iam::239043911459:role/NotifyExportToPlatformDataLake"
+  gc_notify_rds_export_role_arn = "arn:aws:iam::296255494825:role/NotifyExportToPlatformDataLake"
 }

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -123,6 +123,7 @@ resource "aws_glue_trigger" "platform_gc_notify_job" {
   name     = "Platform / GC Notify"
   schedule = "cron(0 5 * * ? *)" # Daily at 5am UTC
   type     = "SCHEDULED"
+  enabled  = false
 
   actions {
     job_name = aws_glue_job.platform_gc_notify_job.name


### PR DESCRIPTION
# Summary
Update the RDS snapshot export to pull from Notify prod.  This will allow us to perform a full data import and start validating that the prod data export and ETL works properly.

The Notify ETL is also being temporarily disabled until a full initial import is performed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668