### PR TITLE
fix: update Notify IAM role in bucket policy

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -64,7 +64,6 @@ data "aws_iam_policy_document" "raw_bucket" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::296255494825:role/NotifyExportToPlatformDataLake",
-        
       ]
     }
     actions = [

--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -63,7 +63,8 @@ data "aws_iam_policy_document" "raw_bucket" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::239043911459:role/NotifyExportToPlatformDataLake",
+        "arn:aws:iam::296255494825:role/NotifyExportToPlatformDataLake",
+        
       ]
     }
     actions = [


### PR DESCRIPTION
# Summary
Update the Raw S3 bucket policy to allow the new Notify IAM role to write objects.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668