### PR TITLE
chore: remove unused Notify raw Glue database

### DIFF
--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -13,11 +13,6 @@ resource "aws_glue_catalog_database" "platform_gc_notify_production" {
   description = "TRANSFORMED: data source path: /platform/gc-notify/*"
 }
 
-resource "aws_glue_catalog_database" "platform_gc_notify_production_raw" {
-  name        = "platform_gc_notify_production_raw"
-  description = "RAW: data source path: /platform/gc-notify/*"
-}
-
 resource "aws_glue_catalog_database" "platform_support_production" {
   name        = "platform_support_production"
   description = "TRANSFORMED: data source path: /platform/support/*"

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -123,7 +123,7 @@ resource "aws_glue_trigger" "platform_gc_notify_job" {
   name     = "Platform / GC Notify"
   schedule = "cron(0 5 * * ? *)" # Daily at 5am UTC
   type     = "SCHEDULED"
-  enabled  = false
+  enabled  = true
 
   actions {
     job_name = aws_glue_job.platform_gc_notify_job.name


### PR DESCRIPTION
# Summary
Remove the Glue raw database that was created for GC Notify data. This is no longer needed as we are able to hardcode the expect raw data schema based on Notify's RDS snapshot export.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668