### PR TITLE
fix: update Notify ETL Raw bucket path

### DIFF
--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -116,6 +116,7 @@ resource "aws_glue_job" "platform_gc_notify_job" {
     "--database_name_transformed"        = aws_glue_catalog_database.platform_gc_notify_production.name
     "--table_config_object"              = "s3://${var.glue_bucket_name}/${aws_s3_object.platform_gc_notify_tables.key}"
     "--table_name_prefix"                = "platform_gc_notify"
+    "--target_env"                       = "production"
   }
 }
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -25,6 +25,7 @@ args = getResolvedOptions(
         "database_name_transformed",
         "table_config_object",
         "table_name_prefix",
+        "target_env",
     ],
 )
 
@@ -37,6 +38,7 @@ TRANSFORMED_PATH = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}"
 DATABASE_NAME_TRANSFORMED = args["database_name_transformed"]
 TABLE_CONFIG_OBJECT = args["table_config_object"]
 TABLE_NAME_PREFIX = args["table_name_prefix"]
+TARGET_ENV = args["target_env"]
 
 # Initialize logging
 logger = logging.getLogger(__name__)
@@ -306,7 +308,7 @@ def process_data():
     transformed data back to S3.
     """
     today = datetime.now().strftime("%Y-%m-%d")
-    path_prefix = f"notification-canada-ca-staging-cluster-{today}/NotificationCanadaCastaging/public."
+    path_prefix = f"notification-canada-ca-{TARGET_ENV}-cluster-{today}/NotificationCanadaCa{TARGET_ENV}/public."
     cloudwatch = boto3.client("cloudwatch")
     s3 = boto3.client("s3")
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
@@ -16,6 +16,7 @@ sys.modules["awsglue.utils"].getResolvedOptions.return_value = {
     "database_name_transformed": "test_database_transformed",
     "table_config_object": "s3://test-config-bucket/test-config-key",
     "table_name_prefix": "test_prefix",
+    "target_env": "test",
 }
 
 
@@ -418,7 +419,7 @@ def test_process_data(
     assert mock_get_new_data.call_count == 2
 
     mock_get_new_data.assert_any_call(
-        f"notification-canada-ca-staging-cluster-2024-05-15/NotificationCanadaCastaging/public.notifications",
+        f"notification-canada-ca-test-cluster-2024-05-15/NotificationCanadaCatest/public.notifications",
         sample_dataset_config[0]["fields"],
         sample_dataset_config[0]["partition_timestamp"],
         sample_dataset_config[0]["partition_cols"],
@@ -426,7 +427,7 @@ def test_process_data(
     )
 
     mock_get_new_data.assert_any_call(
-        f"notification-canada-ca-staging-cluster-2024-05-15/NotificationCanadaCastaging/public.templates",
+        f"notification-canada-ca-test-cluster-2024-05-15/NotificationCanadaCatest/public.templates",
         sample_dataset_config[1]["fields"],
         sample_dataset_config[1]["partition_timestamp"],
         sample_dataset_config[1]["partition_cols"],


### PR DESCRIPTION
# Summary
Update the path of the ETL job to be controlled by a Glue job param.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668