### PR TITLE
docs: add pipeline ownership do the docs

### DIFF
--- a/docs/data/pipelines/bes/crm/salesforce.md
+++ b/docs/data/pipelines/bes/crm/salesforce.md
@@ -3,6 +3,10 @@
 ### :warning: Note
 This dataset is still in testing and only a snapshot of Staging data is available in Superset.
 
+* `Schedule`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: Slack channel #platform-core-services
+
 ## Description
 The [Salesforce](https://canadiandigitalservice.my.salesforce.com/) dataset provides information on customer/client/partner accounts. All user entered information and personally identifiable information (PII) has been removed from the dataset.
 

--- a/docs/data/pipelines/operations/aws/cost-and-usage-report.md
+++ b/docs/data/pipelines/operations/aws/cost-and-usage-report.md
@@ -1,4 +1,9 @@
 # Operations / AWS / Cost and Usage Report
+
+* `Schedule`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: Slack channel #platform-core-services
+
 ## Description
 The AWS [Cost and Usage Report (CUR) 2.0](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) provides detailed billing data exports in  [Parquet format](https://parquet.apache.org/).  It contains line items for all AWS services usage with resource tags, pricing, and cost allocation data. The data is partitioned by time period and account ID, and updated daily.
 

--- a/docs/data/pipelines/platform/gc-forms/templates.md
+++ b/docs/data/pipelines/platform/gc-forms/templates.md
@@ -1,9 +1,13 @@
 # Platform / GC Forms / Templates
 
+* `Schedule`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: Slack channel #platform-core-services
+
 ## Description
 The GC Forms `Templates` dataset provides information on form templates, and the users that own them, in [Parquet format](https://parquet.apache.org/). The role of the form template is to control how the rendered form is presented to users for submission.
 
-There is no form submission data as part of this dataset and only the form owner's name and Government of Canada email address is available in the `users` table. The data is partitioned by month, and updated daily.  It can be queried in Superset as follows:
+There is no form submission data as part of this dataset and only the form owner's Government of Canada email address domain is available in the `users` table. The data is partitioned by month, and updated daily.  It can be queried in Superset as follows:
 
 Note that this dataset also contains a historical snapshot of published form information that was exported from a manually maintained external source.
 

--- a/docs/data/pipelines/platform/gc-notify/export.md
+++ b/docs/data/pipelines/platform/gc-notify/export.md
@@ -1,5 +1,9 @@
 # Platform / GC Notify
 
+* `Schedule`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: Slack channel #platform-core-services
+
 ## Description
 The GC Notify dataset is an export of the following database tables in [Parquet format](https://parquet.apache.org/):
 

--- a/docs/data/pipelines/platform/support/freshdesk.md
+++ b/docs/data/pipelines/platform/support/freshdesk.md
@@ -1,4 +1,9 @@
 # Platform / Support / Freshdesk
+
+* `Schedule`: Daily
+* `Steward`: Platform Core Services
+* `Contact`: Slack channel #platform-core-services
+
 ## Description
 The [Freshdesk](https://www.freshworks.com/freshdesk/) dataset provides information on user support tickets in [Parquet format](https://parquet.apache.org/). All user entered information and personally identifiable information (PII) has been removed from the dataset. The data is partitioned by month, and updated daily.
 

--- a/docs/data/pipelines/template.md
+++ b/docs/data/pipelines/template.md
@@ -1,5 +1,9 @@
 # Dataset name
 
+* `Schedule`: The schedule of pipeline runs. If manual, indicate "Manual"
+* `Steward`: Who is responsible for the pipeline. This can be a person or an organization.
+* `Contact`: Email address or Slack handle of where queries should be directed
+
 ## Description
 
 A simple description of the dataset explaining what it is. 


### PR DESCRIPTION
# Summary
Update the pipeline docs with a section providing the schedule and point of contact for the data pipeline.

Also fixes a discrepancy in the GC Forms pipeline docs.
