### PR TITLE
fix: group Notify CloudWatch metrics by table_name

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -361,7 +361,7 @@ def process_data():
 
         # Publish metrics to CloudWatch
         processing_time = time.time() - start_time
-        publish_metric(cloudwatch, path, len(data), processing_time)
+        publish_metric(cloudwatch, table_name, len(data), processing_time)
 
     logger.info("ETL process completed successfully.")
 


### PR DESCRIPTION
# Summary
Update the published ETL metrics to use the Notify table name rather than the full path.  This will properly group them since the path contains a date, which was causing unique metrics per run.

# Related
- https://github.com/cds-snc/platform-core-services/issues/668