### PR TITLE
Added missing email field in parameters

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -245,6 +245,7 @@ def process_data():
             ],
             "partition_timestamp": "created_at",
             "partition_columns": ["year", "month"],
+            "email_columns": ["deliveryemaildestination"],
         },
         {
             "path": "processed-data/templateToUser",

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -254,7 +254,7 @@ def process_data():
         {
             "path": "processed-data/user",
             "date_columns": ["emailverified", "lastlogin", "createdat", "timestamp"],
-            "partition_timestamp": "lastlogin",  # User created date is currently in this field
+            "partition_timestamp": "lastlogin",  # User created date is currently in this field.
             "partition_columns": ["year", "month"],
             "drop_columns": ["name"],
             "email_columns": ["email"],


### PR DESCRIPTION
# Summary | Résumé

deliveryemaildestination field was not properly cleaned-up. This is because the field was missing in the parameters
https://github.com/cds-snc/platform-core-services/issues/736#event-17591700799


@cds-snc/platform-core-services 