### PR TITLE
feat: Staging environment config setup

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/lambda.tf
+++ b/terragrunt/aws/export/platform/gc_notify/lambda.tf
@@ -5,7 +5,7 @@ module "platform_gc_notify_export" {
   source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.4.2"
 
   lambda_name                = local.gc_notify_lambda_name
-  lambda_schedule_expression = "cron(0 4 ? * * *)" # Daily at 4am UTC
+  lambda_schedule_expression = local.cron_expression
   lambda_timeout             = "60"
   lambda_architectures       = ["arm64"]
 

--- a/terragrunt/aws/export/platform/gc_notify/locals.tf
+++ b/terragrunt/aws/export/platform/gc_notify/locals.tf
@@ -1,5 +1,9 @@
 locals {
-  gc_notify_env                 = "production"
+  is_production = var.env == "production"
+
+  cron_expression               = local.is_production ? "cron(0 4 ? * * *)" : "cron(0 0 1 1 1 1970)" # Daily at 4am UTC for prod, never otherwise
+  gc_notify_account_id          = local.is_production ? "296255494825" : "239043911459"
+  gc_notify_env                 = var.env
   gc_notify_lambda_name         = "platform-gc-notify-export"
-  gc_notify_rds_export_role_arn = "arn:aws:iam::296255494825:role/NotifyExportToPlatformDataLake"
+  gc_notify_rds_export_role_arn = "arn:aws:iam::${local.gc_notify_account_id}:role/NotifyExportToPlatformDataLake"
 }

--- a/terragrunt/aws/export/platform/gc_notify/variables.tf
+++ b/terragrunt/aws/export/platform/gc_notify/variables.tf
@@ -8,6 +8,11 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "env" {
+  description = "The environment for the resources."
+  type        = string
+}
+
 variable "raw_bucket_name" {
   description = "The name of the Raw bucket"
   type        = string

--- a/terragrunt/aws/export/platform/support/freshdesk/lambda.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/lambda.tf
@@ -5,7 +5,7 @@ module "platform_support_freshdesk_export" {
   source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v10.4.2"
 
   lambda_name                = local.freshdesk_lambda_name
-  lambda_schedule_expression = "cron(0 5 * * ? *)" # 5am UTC every day
+  lambda_schedule_expression = local.cron_expression
   lambda_timeout             = "300"
   lambda_architectures       = ["arm64"]
   s3_arn_write_path          = "${var.raw_bucket_arn}/${local.freshdesk_export_path}/*"

--- a/terragrunt/aws/export/platform/support/freshdesk/locals.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  is_production = var.env == "production"
+
+  cron_expression       = local.is_production ? "cron(0 5 * * ? *)" : "cron(0 0 1 1 1 1970)" # Daily at 5am UTC for prod, never otherwise
   freshdesk_export_path = "platform/support/freshdesk"
   freshdesk_lambda_name = "platform-support-freshdesk-export"
 }

--- a/terragrunt/aws/export/platform/support/freshdesk/variables.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/variables.tf
@@ -3,6 +3,11 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "env" {
+  description = "The environment for the resources."
+  type        = string
+}
+
 variable "freshdesk_api_key" {
   description = "The Freshdesk API key to use for data exports."
   type        = string

--- a/terragrunt/aws/export/tasks.tf
+++ b/terragrunt/aws/export/tasks.tf
@@ -1,6 +1,7 @@
 module "platform_notify_export" {
   source = "./platform/gc_notify"
 
+  env                        = var.env
   account_id                 = var.account_id
   raw_bucket_name            = var.raw_bucket_name
   sns_topic_alarm_action_arn = var.sns_topic_alarm_action_arn
@@ -12,6 +13,7 @@ module "platform_notify_export" {
 module "platform_support_freshdesk_export" {
   source = "./platform/support/freshdesk"
 
+  env                        = var.env
   freshdesk_api_key          = var.freshdesk_api_key
   raw_bucket_arn             = var.raw_bucket_arn
   raw_bucket_name            = var.raw_bucket_name

--- a/terragrunt/aws/glue/crawlers.tf
+++ b/terragrunt/aws/glue/crawlers.tf
@@ -77,7 +77,8 @@ resource "aws_glue_crawler" "platform_support_freshdesk_production" {
       Version              = 1
   })
 
-  schedule = "cron(00 6 1-10 * ? *)" # 6am UTC check for schema changes on the first 10 days of each month
+  # 6am UTC check for schema changes on the first 10 days of each month
+  schedule = local.is_production ? "cron(00 6 1-10 * ? *)" : null
 }
 
 #
@@ -107,7 +108,8 @@ resource "aws_glue_crawler" "operations_aws_production_cost_usage_report" {
       Version              = 1
   })
 
-  schedule = "cron(00 7 1-10 * ? *)" # Run for the first 10 days of each month to create the new partition key
+  # Run for the first 10 days of each month to create the new partition key
+  schedule = local.is_production ? "cron(00 7 1-10 * ? *)" : null
 }
 
 #
@@ -138,7 +140,8 @@ resource "aws_glue_crawler" "operations_aws_production_account_tags" {
       Version              = 1
   })
 
-  schedule = "cron(00 7 1 * ? *)" # Check for schema changes each month
+  # Check for schema changes each month
+  schedule = local.is_production ? "cron(00 7 1 * ? *)" : null
 }
 
 # JSON classifier for arrays of objects

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -51,6 +51,7 @@ resource "aws_glue_trigger" "platform_gc_forms_job" {
   name     = "Platform / GC Forms"
   schedule = "cron(00 2 * * ? *)" # 2am UTC every day
   type     = "SCHEDULED"
+  enabled  = local.is_production
 
   actions {
     job_name = aws_glue_job.platform_gc_forms_job.name
@@ -137,7 +138,7 @@ resource "aws_glue_trigger" "platform_gc_notify_job" {
   name     = "Platform / GC Notify"
   schedule = "cron(0 5 * * ? *)" # Daily at 5am UTC
   type     = "SCHEDULED"
-  enabled  = true
+  enabled  = local.is_production
 
   actions {
     job_name = aws_glue_job.platform_gc_notify_job.name
@@ -197,6 +198,7 @@ resource "aws_glue_trigger" "platform_support_freshdesk" {
   name     = "Platform / Support / Freshdesk"
   schedule = "cron(00 7 * * ? *)" # 7am UTC every day
   type     = "SCHEDULED"
+  enabled  = local.is_production
 
   actions {
     job_name = aws_glue_job.platform_support_freshdesk.name
@@ -256,6 +258,7 @@ resource "aws_glue_trigger" "bes_crm_salesforce" {
   name     = "BES / CRM / Salesforce"
   schedule = "cron(00 7 * * ? *)" # 7am UTC every day
   type     = "SCHEDULED"
+  enabled  = local.is_production
 
   actions {
     job_name = aws_glue_job.bes_crm_salesforce.name

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  is_production = var.env == "production"
+
   # To grant a Superset IAM role access to a Glue catalog database, the role ARN must end with the database name:
   # - arn:aws:iam::123456789012:role/SupersetAthenaRead-datatabase_name
   # The Superset role ARNs are managed by the `superset_iam_role_arns` input variable.

--- a/terragrunt/env/staging/alarms/.terraform.lock.hcl
+++ b/terragrunt/env/staging/alarms/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:0cMARQKxeJIHYi+p1Yg391n3oytz92H0/E/gdTSo1vg=",
+    "h1:2vyaumyNsiPVqJsMQwaSbrrssj6HcJVspxJawhu0UsU=",
+    "h1:7S6mkqyB8tdNhgukHGMZEbEpkp0uGmBAuNB/u9cSXss=",
+    "h1:953uFkvlqGOHtO6j+aeJELqmwI5z7uV28TnkKYy6pSA=",
+    "h1:BEBRvS6L1361geJqMvEG5edra5NDbYO1X7LpzKtEl4s=",
+    "h1:GDDvO45gw0VNyoEy6ShUvfqQl8P5tfxiSej3638yBqo=",
+    "h1:MFzR9nx3IOChf9ctdlJiSVA5Wr+fzUs5Yyr/xo5XKT4=",
+    "h1:U4C3lmRwLC8WbE9bJ2/iKLkxHRZga48Elto/FelLzDc=",
+    "h1:WbQUOeVoJXKb9glRLC7pRYUGX5nS7dkpYt5gmjfjYe0=",
+    "h1:WwuqNl8roShq7eOWRKLd6FDFRrr90XwEBVDp+7/9MWU=",
+    "h1:Y60/O4cEWdXZhV5Yq3pZ1CEE/3aCJYdNj3s13KyjtMs=",
+    "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
+    "h1:rIcRZfPZXOp3lUPM+TVqvO2JTWOqUuzQ7DDQ3wb9q60=",
+    "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
+    "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
+    "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
+    "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
+    "zh:1a4b57a5043dcca64d8b8bae8b30ef4f6b98ed2144f792f39c4e816d3f1e2c56",
+    "zh:1bf00a67f39e67664337bde065180d41d952242801ebcd1c777061d4ffaa1cc1",
+    "zh:24c549f53d6bd022af31426d3e78f21264d8a72409821669e7fd41966ae68b2b",
+    "zh:3abda50bbddb35d86081fe39522e995280aea7f004582c4af22112c03ac8b375",
+    "zh:7388ed7f21ce2eb46bd9066626ce5f3e2a5705f67f643acce8ae71972f66eaf6",
+    "zh:96740f2ff94e5df2b2d29a5035a1a1026fe821f61712b2099b224fb2c2277663",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f399f8e8683a3a3a6d63a41c7c3a5a5f266eedef40ea69eba75bacf03699879",
+    "zh:bcf2b288d4706ebd198f75d2159663d657535483331107f2cdef381f10688baf",
+    "zh:cc76c8a9fc3bad05a8779c1f80fe8c388734f1ec1dd0affa863343490527b466",
+    "zh:de4359cf1b057bfe7a563be93829ec64bf72e7a2b85a72d075238081ef5eb1db",
+    "zh:e208fa77051a1f9fa1eff6c5c58aabdcab0de1695b97cdea7b8dd81df3e0ed73",
+  ]
+}

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -1,0 +1,26 @@
+terraform {
+  source = "../../../aws//alarms"
+}
+
+dependencies {
+  paths = ["../glue"]
+}
+
+dependency "glue" {
+  config_path                             = "../glue"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    glue_crawler_log_group_name = "mock-glue-crawler-log-group"
+    glue_etl_log_group_name     = "mock-glue-etl-log-group"
+  }
+}
+
+inputs = {
+  glue_crawler_log_group_name = dependency.glue.outputs.glue_crawler_log_group_name
+  glue_etl_log_group_name     = dependency.glue.outputs.glue_etl_log_group_name
+}
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/terragrunt/env/staging/athena/.terraform.lock.hcl
+++ b/terragrunt/env/staging/athena/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:0cMARQKxeJIHYi+p1Yg391n3oytz92H0/E/gdTSo1vg=",
+    "h1:2vyaumyNsiPVqJsMQwaSbrrssj6HcJVspxJawhu0UsU=",
+    "h1:7S6mkqyB8tdNhgukHGMZEbEpkp0uGmBAuNB/u9cSXss=",
+    "h1:953uFkvlqGOHtO6j+aeJELqmwI5z7uV28TnkKYy6pSA=",
+    "h1:BEBRvS6L1361geJqMvEG5edra5NDbYO1X7LpzKtEl4s=",
+    "h1:GDDvO45gw0VNyoEy6ShUvfqQl8P5tfxiSej3638yBqo=",
+    "h1:MFzR9nx3IOChf9ctdlJiSVA5Wr+fzUs5Yyr/xo5XKT4=",
+    "h1:U4C3lmRwLC8WbE9bJ2/iKLkxHRZga48Elto/FelLzDc=",
+    "h1:WbQUOeVoJXKb9glRLC7pRYUGX5nS7dkpYt5gmjfjYe0=",
+    "h1:WwuqNl8roShq7eOWRKLd6FDFRrr90XwEBVDp+7/9MWU=",
+    "h1:Y60/O4cEWdXZhV5Yq3pZ1CEE/3aCJYdNj3s13KyjtMs=",
+    "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
+    "h1:rIcRZfPZXOp3lUPM+TVqvO2JTWOqUuzQ7DDQ3wb9q60=",
+    "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
+    "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
+    "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
+    "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
+    "zh:1a4b57a5043dcca64d8b8bae8b30ef4f6b98ed2144f792f39c4e816d3f1e2c56",
+    "zh:1bf00a67f39e67664337bde065180d41d952242801ebcd1c777061d4ffaa1cc1",
+    "zh:24c549f53d6bd022af31426d3e78f21264d8a72409821669e7fd41966ae68b2b",
+    "zh:3abda50bbddb35d86081fe39522e995280aea7f004582c4af22112c03ac8b375",
+    "zh:7388ed7f21ce2eb46bd9066626ce5f3e2a5705f67f643acce8ae71972f66eaf6",
+    "zh:96740f2ff94e5df2b2d29a5035a1a1026fe821f61712b2099b224fb2c2277663",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f399f8e8683a3a3a6d63a41c7c3a5a5f266eedef40ea69eba75bacf03699879",
+    "zh:bcf2b288d4706ebd198f75d2159663d657535483331107f2cdef381f10688baf",
+    "zh:cc76c8a9fc3bad05a8779c1f80fe8c388734f1ec1dd0affa863343490527b466",
+    "zh:de4359cf1b057bfe7a563be93829ec64bf72e7a2b85a72d075238081ef5eb1db",
+    "zh:e208fa77051a1f9fa1eff6c5c58aabdcab0de1695b97cdea7b8dd81df3e0ed73",
+  ]
+}

--- a/terragrunt/env/staging/athena/terragrunt.hcl
+++ b/terragrunt/env/staging/athena/terragrunt.hcl
@@ -1,0 +1,24 @@
+terraform {
+  source = "../../../aws//athena"
+}
+
+dependencies {
+  paths = ["../buckets"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    athena_bucket_name = "mock-athena-bucket"
+  }
+}
+
+inputs = {
+  athena_bucket_name = dependency.buckets.outputs.athena_bucket_name
+}
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/terragrunt/env/staging/buckets/.terraform.lock.hcl
+++ b/terragrunt/env/staging/buckets/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = ">= 4.9.0, ~> 5.0"
+  hashes = [
+    "h1:0cMARQKxeJIHYi+p1Yg391n3oytz92H0/E/gdTSo1vg=",
+    "h1:2vyaumyNsiPVqJsMQwaSbrrssj6HcJVspxJawhu0UsU=",
+    "h1:7S6mkqyB8tdNhgukHGMZEbEpkp0uGmBAuNB/u9cSXss=",
+    "h1:953uFkvlqGOHtO6j+aeJELqmwI5z7uV28TnkKYy6pSA=",
+    "h1:BEBRvS6L1361geJqMvEG5edra5NDbYO1X7LpzKtEl4s=",
+    "h1:GDDvO45gw0VNyoEy6ShUvfqQl8P5tfxiSej3638yBqo=",
+    "h1:MFzR9nx3IOChf9ctdlJiSVA5Wr+fzUs5Yyr/xo5XKT4=",
+    "h1:U4C3lmRwLC8WbE9bJ2/iKLkxHRZga48Elto/FelLzDc=",
+    "h1:WbQUOeVoJXKb9glRLC7pRYUGX5nS7dkpYt5gmjfjYe0=",
+    "h1:WwuqNl8roShq7eOWRKLd6FDFRrr90XwEBVDp+7/9MWU=",
+    "h1:Y60/O4cEWdXZhV5Yq3pZ1CEE/3aCJYdNj3s13KyjtMs=",
+    "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
+    "h1:rIcRZfPZXOp3lUPM+TVqvO2JTWOqUuzQ7DDQ3wb9q60=",
+    "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
+    "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
+    "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
+    "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
+    "zh:1a4b57a5043dcca64d8b8bae8b30ef4f6b98ed2144f792f39c4e816d3f1e2c56",
+    "zh:1bf00a67f39e67664337bde065180d41d952242801ebcd1c777061d4ffaa1cc1",
+    "zh:24c549f53d6bd022af31426d3e78f21264d8a72409821669e7fd41966ae68b2b",
+    "zh:3abda50bbddb35d86081fe39522e995280aea7f004582c4af22112c03ac8b375",
+    "zh:7388ed7f21ce2eb46bd9066626ce5f3e2a5705f67f643acce8ae71972f66eaf6",
+    "zh:96740f2ff94e5df2b2d29a5035a1a1026fe821f61712b2099b224fb2c2277663",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f399f8e8683a3a3a6d63a41c7c3a5a5f266eedef40ea69eba75bacf03699879",
+    "zh:bcf2b288d4706ebd198f75d2159663d657535483331107f2cdef381f10688baf",
+    "zh:cc76c8a9fc3bad05a8779c1f80fe8c388734f1ec1dd0affa863343490527b466",
+    "zh:de4359cf1b057bfe7a563be93829ec64bf72e7a2b85a72d075238081ef5eb1db",
+    "zh:e208fa77051a1f9fa1eff6c5c58aabdcab0de1695b97cdea7b8dd81df3e0ed73",
+  ]
+}

--- a/terragrunt/env/staging/buckets/terragrunt.hcl
+++ b/terragrunt/env/staging/buckets/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../aws//buckets"
+}

--- a/terragrunt/env/staging/env_vars.hcl
+++ b/terragrunt/env/staging/env_vars.hcl
@@ -1,0 +1,5 @@
+inputs = {
+  account_id        = "123456789012"
+  env               = "staging"
+  billing_tag_value = "PlatformDataLake"
+}

--- a/terragrunt/env/staging/env_vars.hcl
+++ b/terragrunt/env/staging/env_vars.hcl
@@ -1,5 +1,5 @@
 inputs = {
-  account_id        = "123456789012"
+  account_id        = "454671348950"
   env               = "staging"
   billing_tag_value = "PlatformDataLake"
 }

--- a/terragrunt/env/staging/export/.terraform.lock.hcl
+++ b/terragrunt/env/staging/export/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:0cMARQKxeJIHYi+p1Yg391n3oytz92H0/E/gdTSo1vg=",
+    "h1:2vyaumyNsiPVqJsMQwaSbrrssj6HcJVspxJawhu0UsU=",
+    "h1:7S6mkqyB8tdNhgukHGMZEbEpkp0uGmBAuNB/u9cSXss=",
+    "h1:953uFkvlqGOHtO6j+aeJELqmwI5z7uV28TnkKYy6pSA=",
+    "h1:BEBRvS6L1361geJqMvEG5edra5NDbYO1X7LpzKtEl4s=",
+    "h1:GDDvO45gw0VNyoEy6ShUvfqQl8P5tfxiSej3638yBqo=",
+    "h1:MFzR9nx3IOChf9ctdlJiSVA5Wr+fzUs5Yyr/xo5XKT4=",
+    "h1:U4C3lmRwLC8WbE9bJ2/iKLkxHRZga48Elto/FelLzDc=",
+    "h1:WbQUOeVoJXKb9glRLC7pRYUGX5nS7dkpYt5gmjfjYe0=",
+    "h1:WwuqNl8roShq7eOWRKLd6FDFRrr90XwEBVDp+7/9MWU=",
+    "h1:Y60/O4cEWdXZhV5Yq3pZ1CEE/3aCJYdNj3s13KyjtMs=",
+    "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
+    "h1:rIcRZfPZXOp3lUPM+TVqvO2JTWOqUuzQ7DDQ3wb9q60=",
+    "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
+    "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
+    "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
+    "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
+    "zh:1a4b57a5043dcca64d8b8bae8b30ef4f6b98ed2144f792f39c4e816d3f1e2c56",
+    "zh:1bf00a67f39e67664337bde065180d41d952242801ebcd1c777061d4ffaa1cc1",
+    "zh:24c549f53d6bd022af31426d3e78f21264d8a72409821669e7fd41966ae68b2b",
+    "zh:3abda50bbddb35d86081fe39522e995280aea7f004582c4af22112c03ac8b375",
+    "zh:7388ed7f21ce2eb46bd9066626ce5f3e2a5705f67f643acce8ae71972f66eaf6",
+    "zh:96740f2ff94e5df2b2d29a5035a1a1026fe821f61712b2099b224fb2c2277663",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f399f8e8683a3a3a6d63a41c7c3a5a5f266eedef40ea69eba75bacf03699879",
+    "zh:bcf2b288d4706ebd198f75d2159663d657535483331107f2cdef381f10688baf",
+    "zh:cc76c8a9fc3bad05a8779c1f80fe8c388734f1ec1dd0affa863343490527b466",
+    "zh:de4359cf1b057bfe7a563be93829ec64bf72e7a2b85a72d075238081ef5eb1db",
+    "zh:e208fa77051a1f9fa1eff6c5c58aabdcab0de1695b97cdea7b8dd81df3e0ed73",
+  ]
+}

--- a/terragrunt/env/staging/export/terragrunt.hcl
+++ b/terragrunt/env/staging/export/terragrunt.hcl
@@ -1,0 +1,39 @@
+terraform {
+  source = "../../../aws//export"
+}
+
+dependencies {
+  paths = ["../buckets", "../alarms"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    raw_bucket_arn  = "arn:aws:s3:::mock-raw-bucket"
+    raw_bucket_name = "mock-raw-bucket"
+  }
+}
+
+dependency "alarms" {
+  config_path                             = "../alarms"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    sns_topic_alarm_action_arn = "arn:aws:sns:ca-central-1:123456789012:mock-alarm-topic"
+    sns_topic_ok_action_arn    = "arn:aws:sns:ca-central-1:123456789012:mock-ok-topic"
+  }
+}
+
+inputs = {
+  raw_bucket_arn  = dependency.buckets.outputs.raw_bucket_arn
+  raw_bucket_name = dependency.buckets.outputs.raw_bucket_name
+
+  sns_topic_alarm_action_arn = dependency.alarms.outputs.sns_topic_alarm_action_arn
+  sns_topic_ok_action_arn    = dependency.alarms.outputs.sns_topic_ok_action_arn
+}
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/terragrunt/env/staging/glue/.terraform.lock.hcl
+++ b/terragrunt/env/staging/glue/.terraform.lock.hcl
@@ -1,0 +1,77 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:aTsKLhA0m6ZW560baooNkF1t47TZvpBvaoPEI8wQpDo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:0cMARQKxeJIHYi+p1Yg391n3oytz92H0/E/gdTSo1vg=",
+    "h1:2vyaumyNsiPVqJsMQwaSbrrssj6HcJVspxJawhu0UsU=",
+    "h1:7S6mkqyB8tdNhgukHGMZEbEpkp0uGmBAuNB/u9cSXss=",
+    "h1:953uFkvlqGOHtO6j+aeJELqmwI5z7uV28TnkKYy6pSA=",
+    "h1:BEBRvS6L1361geJqMvEG5edra5NDbYO1X7LpzKtEl4s=",
+    "h1:GDDvO45gw0VNyoEy6ShUvfqQl8P5tfxiSej3638yBqo=",
+    "h1:MFzR9nx3IOChf9ctdlJiSVA5Wr+fzUs5Yyr/xo5XKT4=",
+    "h1:U4C3lmRwLC8WbE9bJ2/iKLkxHRZga48Elto/FelLzDc=",
+    "h1:WbQUOeVoJXKb9glRLC7pRYUGX5nS7dkpYt5gmjfjYe0=",
+    "h1:WwuqNl8roShq7eOWRKLd6FDFRrr90XwEBVDp+7/9MWU=",
+    "h1:Y60/O4cEWdXZhV5Yq3pZ1CEE/3aCJYdNj3s13KyjtMs=",
+    "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
+    "h1:rIcRZfPZXOp3lUPM+TVqvO2JTWOqUuzQ7DDQ3wb9q60=",
+    "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
+    "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
+    "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
+    "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
+    "zh:1a4b57a5043dcca64d8b8bae8b30ef4f6b98ed2144f792f39c4e816d3f1e2c56",
+    "zh:1bf00a67f39e67664337bde065180d41d952242801ebcd1c777061d4ffaa1cc1",
+    "zh:24c549f53d6bd022af31426d3e78f21264d8a72409821669e7fd41966ae68b2b",
+    "zh:3abda50bbddb35d86081fe39522e995280aea7f004582c4af22112c03ac8b375",
+    "zh:7388ed7f21ce2eb46bd9066626ce5f3e2a5705f67f643acce8ae71972f66eaf6",
+    "zh:96740f2ff94e5df2b2d29a5035a1a1026fe821f61712b2099b224fb2c2277663",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f399f8e8683a3a3a6d63a41c7c3a5a5f266eedef40ea69eba75bacf03699879",
+    "zh:bcf2b288d4706ebd198f75d2159663d657535483331107f2cdef381f10688baf",
+    "zh:cc76c8a9fc3bad05a8779c1f80fe8c388734f1ec1dd0affa863343490527b466",
+    "zh:de4359cf1b057bfe7a563be93829ec64bf72e7a2b85a72d075238081ef5eb1db",
+    "zh:e208fa77051a1f9fa1eff6c5c58aabdcab0de1695b97cdea7b8dd81df3e0ed73",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:6XyefmvbkprppmYbGmMcQW5NB4w6C363SSShzuhF4R0=",
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}

--- a/terragrunt/env/staging/glue/terragrunt.hcl
+++ b/terragrunt/env/staging/glue/terragrunt.hcl
@@ -1,0 +1,38 @@
+terraform {
+  source = "../../../aws//glue"
+}
+
+dependencies {
+  paths = ["../buckets"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    curated_bucket_arn      = "arn:aws:s3:::mock-curated-bucket"
+    curated_bucket_name     = "mock-curated-bucket"
+    glue_bucket_arn         = "arn:aws:s3:::mock-glue-bucket"
+    glue_bucket_name        = "mock-glue-bucket"
+    raw_bucket_arn          = "arn:aws:s3:::mock-raw-bucket"
+    raw_bucket_name         = "mock-raw-bucket"
+    transformed_bucket_arn  = "arn:aws:s3:::mock-transformed-bucket"
+    transformed_bucket_name = "mock-transformed-bucket"
+  }
+}
+
+inputs = {
+  curated_bucket_arn      = dependency.buckets.outputs.curated_bucket_arn
+  curated_bucket_name     = dependency.buckets.outputs.curated_bucket_name
+  glue_bucket_arn         = dependency.buckets.outputs.glue_bucket_arn
+  glue_bucket_name        = dependency.buckets.outputs.glue_bucket_name
+  raw_bucket_arn          = dependency.buckets.outputs.raw_bucket_arn
+  raw_bucket_name         = dependency.buckets.outputs.raw_bucket_name
+  transformed_bucket_arn  = dependency.buckets.outputs.transformed_bucket_arn
+  transformed_bucket_name = dependency.buckets.outputs.transformed_bucket_name
+}
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}


### PR DESCRIPTION
# Summary
Add the Terragrunt configuration for a Staging environment and update the scheduled tasks to continue running Prod exports but disable them in Staging.

This PR will not be creating any Staging resources as the new AWS account does not exist yet.

## ℹ️ Note
It is expected that there is no Terraform plan for this change since it does not change the Prod infrastructure state and the workflows to create Staging infrastructure do not exist yet.