### PR TITLE
fix: Terraform issues with Staging env create

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/locals.tf
+++ b/terragrunt/aws/export/platform/gc_notify/locals.tf
@@ -1,7 +1,7 @@
 locals {
   is_production = var.env == "production"
 
-  cron_expression               = local.is_production ? "cron(0 4 ? * * *)" : "cron(0 0 1 1 1 1970)" # Daily at 4am UTC for prod, never otherwise
+  cron_expression               = local.is_production ? "cron(0 4 ? * * *)" : "cron(0 0 1 1 ? 1970)" # Daily at 4am UTC for prod, never otherwise
   gc_notify_account_id          = local.is_production ? "296255494825" : "239043911459"
   gc_notify_env                 = var.env
   gc_notify_lambda_name         = "platform-gc-notify-export"

--- a/terragrunt/aws/export/platform/support/freshdesk/locals.tf
+++ b/terragrunt/aws/export/platform/support/freshdesk/locals.tf
@@ -1,7 +1,7 @@
 locals {
   is_production = var.env == "production"
 
-  cron_expression       = local.is_production ? "cron(0 5 * * ? *)" : "cron(0 0 1 1 1 1970)" # Daily at 5am UTC for prod, never otherwise
+  cron_expression       = local.is_production ? "cron(0 5 * * ? *)" : "cron(0 0 1 1 ? 1970)" # Daily at 5am UTC for prod, never otherwise
   freshdesk_export_path = "platform/support/freshdesk"
   freshdesk_lambda_name = "platform-support-freshdesk-export"
 }

--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -1,39 +1,39 @@
 resource "aws_glue_catalog_database" "platform_gc_forms_production" {
-  name        = "platform_gc_forms_${var.env}"
+  name        = "platform_gc_forms_production"
   description = "TRANSFORMED: data source path: /platform/gc-forms/*"
 }
 
 resource "aws_glue_catalog_database" "platform_gc_forms_production_raw" {
-  name        = "platform_gc_forms_${var.env}_raw"
+  name        = "platform_gc_forms_production_raw"
   description = "RAW: data source path: /platform/gc-forms/*"
 }
 
 resource "aws_glue_catalog_database" "platform_gc_notify_production" {
-  name        = "platform_gc_notify_${var.env}"
+  name        = "platform_gc_notify_production"
   description = "TRANSFORMED: data source path: /platform/gc-notify/*"
 }
 
 resource "aws_glue_catalog_database" "platform_support_production" {
-  name        = "platform_support_${var.env}"
+  name        = "platform_support_production"
   description = "TRANSFORMED: data source path: /platform/support/*"
 }
 
 resource "aws_glue_catalog_database" "platform_support_production_raw" {
-  name        = "platform_support_${var.env}_raw"
+  name        = "platform_support_production_raw"
   description = "RAW: data source path: /platform/support/*"
 }
 
 resource "aws_glue_catalog_database" "bes_crm_salesforce_production" {
-  name        = "bes_crm_salesforce_${var.env}"
+  name        = "bes_crm_salesforce_production"
   description = "TRANSFORMED: data source path: /bes/crm/salesforce/*"
 }
 
 resource "aws_glue_catalog_database" "operations_aws_production" {
-  name        = "operations_aws_${var.env}"
+  name        = "operations_aws_production"
   description = "TRANSFORMED: data source path: /operations/aws/*"
 }
 
 resource "aws_glue_catalog_database" "operations_aws_production_raw" {
-  name        = "operations_aws_${var.env}_raw"
+  name        = "operations_aws_production_raw"
   description = "RAW: data source path: /operations/aws/*"
 }


### PR DESCRIPTION
# Summary
Update the Terraform with fixes required to fully create the Staging infrastructure.  This included the following:

- Correcting the cron expression to include the `?` wildcard for day of the week.
- Updating the database names to be suffixed with `_production`.  We will need to adjust the Superset IAM roles before we can create `_staging` Glue databases.
