### PR TITLE
feat: create anomaly detection alarms for GC Forms

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -105,7 +105,7 @@ resource "aws_cloudwatch_metric_alarm" "anomaly_detection" {
   metric_query {
     id          = "expected_value"
     expression  = "ANOMALY_DETECTION_BAND(actual_value, ${each.value.standard_deviation})"
-    label       = "Processed Records (Expected)"
+    label       = "${each.value.metric_name} (Expected)"
     return_data = "true"
   }
 

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -84,33 +84,43 @@ resource "aws_cloudwatch_metric_alarm" "glue_job_failures" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "platform_gc_forms_etl_user_processed_record_anomaly" {
-  alarm_name          = "platform-gc-forms-etl-user-processed-record-anomaly"
-  alarm_description   = "'Platform / GC Forms' ETL job anomaly detection for the 'user' dataset."
+resource "aws_cloudwatch_metric_alarm" "anomaly_detection" {
+  for_each = var.env == "production" ? tomap({
+    for alarm in local.anomaly_detection_alarms :
+    alarm.name => {
+      metric_name        = alarm.metric_name
+      namespace          = alarm.namespace
+      dataset            = alarm.dataset
+      standard_deviation = alarm.standard_deviation
+    }
+  }) : tomap({})
+
+  alarm_name          = "anomaly-${each.key}"
+  alarm_description   = "Anomaly detection for '${each.value.namespace} / ${each.value.dataset} / ${each.value.metric_name}'"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
-  threshold_metric_id = "processed_records_expected"
+  threshold_metric_id = "expected_value"
   evaluation_periods  = 1
   treat_missing_data  = "notBreaching"
 
   metric_query {
-    id          = "processed_records_expected"
-    expression  = "ANOMALY_DETECTION_BAND(processed_records, 0.5)" # standard deviations
+    id          = "expected_value"
+    expression  = "ANOMALY_DETECTION_BAND(actual_value, ${each.value.standard_deviation})"
     label       = "Processed Records (Expected)"
     return_data = "true"
   }
 
   metric_query {
-    id          = "processed_records"
+    id          = "actual_value"
     return_data = "true"
     metric {
-      metric_name = "ProcessedRecordCount"
-      namespace   = "data-lake/etl/gc-forms"
+      metric_name = each.value.metric_name
+      namespace   = each.value.namespace
       period      = 86400 # 1 day
       stat        = "Sum"
       unit        = "Count"
 
       dimensions = {
-        Dataset = "processed-data/user"
+        Dataset = each.value.dataset
       }
     }
   }

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -5,49 +5,49 @@ locals {
       namespace          = "data-lake/etl/gc-forms"
       dataset            = "processed-data/submissions"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 1
+      standard_deviation = 2
     },
     {
       name               = "platform-gc-forms-etl-template-processed-record"
       namespace          = "data-lake/etl/gc-forms"
       dataset            = "processed-data/template"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 0.5
+      standard_deviation = 2
     },
     {
       name               = "platform-gc-forms-etl-template-to-user-processed-record"
       namespace          = "data-lake/etl/gc-forms"
       dataset            = "processed-data/templateToUser"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 0.5
+      standard_deviation = 2
     },
     {
       name               = "platform-gc-forms-etl-user-processed-record"
       namespace          = "data-lake/etl/gc-forms"
       dataset            = "processed-data/user"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 0.5
+      standard_deviation = 2
     },
     {
       name               = "platform-gc-notify-etl-notification-history-processed-record"
       namespace          = "data-lake/etl/gc-notify"
       dataset            = "notification_history"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 1
+      standard_deviation = 2
     },
     {
       name               = "platform-gc-notify-etl-notifications-processed-record"
       namespace          = "data-lake/etl/gc-notify"
       dataset            = "notifications"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 1
+      standard_deviation = 2
     },
     {
       name               = "platform-gc-notify-etl-users-processed-record"
       namespace          = "data-lake/etl/gc-notify"
       dataset            = "users"
       metric_name        = "ProcessedRecordCount"
-      standard_deviation = 0.5
+      standard_deviation = 2
     }
   ]
 

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -31,21 +31,21 @@ locals {
     {
       name               = "platform-gc-notify-etl-notification-history-processed-record"
       namespace          = "data-lake/etl/gc-notify"
-      dataset            = "processed-data/notification_history"
+      dataset            = "notification_history"
       metric_name        = "ProcessedRecordCount"
       standard_deviation = 1
     },
     {
       name               = "platform-gc-notify-etl-notifications-processed-record"
       namespace          = "data-lake/etl/gc-notify"
-      dataset            = "processed-data/notifications"
+      dataset            = "notifications"
       metric_name        = "ProcessedRecordCount"
       standard_deviation = 1
     },
     {
       name               = "platform-gc-notify-etl-users-processed-record"
       namespace          = "data-lake/etl/gc-notify"
-      dataset            = "processed-data/users"
+      dataset            = "users"
       metric_name        = "ProcessedRecordCount"
       standard_deviation = 0.5
     }

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -27,6 +27,27 @@ locals {
       dataset            = "processed-data/user"
       metric_name        = "ProcessedRecordCount"
       standard_deviation = 0.5
+    },
+    {
+      name               = "platform-gc-notify-etl-notification-history-processed-record"
+      namespace          = "data-lake/etl/gc-notify"
+      dataset            = "processed-data/notification_history"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 1
+    },
+    {
+      name               = "platform-gc-notify-etl-notifications-processed-record"
+      namespace          = "data-lake/etl/gc-notify"
+      dataset            = "processed-data/notifications"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 1
+    },
+    {
+      name               = "platform-gc-notify-etl-users-processed-record"
+      namespace          = "data-lake/etl/gc-notify"
+      dataset            = "processed-data/users"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 0.5
     }
   ]
 

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -1,4 +1,35 @@
 locals {
+  anomaly_detection_alarms = [
+    {
+      name               = "platform-gc-forms-etl-submissions-processed-record"
+      namespace          = "data-lake/etl/gc-forms"
+      dataset            = "processed-data/submissions"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 1
+    },
+    {
+      name               = "platform-gc-forms-etl-template-processed-record"
+      namespace          = "data-lake/etl/gc-forms"
+      dataset            = "processed-data/template"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 0.5
+    },
+    {
+      name               = "platform-gc-forms-etl-template-to-user-processed-record"
+      namespace          = "data-lake/etl/gc-forms"
+      dataset            = "processed-data/templateToUser"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 0.5
+    },
+    {
+      name               = "platform-gc-forms-etl-user-processed-record"
+      namespace          = "data-lake/etl/gc-forms"
+      dataset            = "processed-data/user"
+      metric_name        = "ProcessedRecordCount"
+      standard_deviation = 0.5
+    }
+  ]
+
   data_lake_namespace                      = "data-lake"
   glue_crawler_metric_filter_error_pattern = "ERROR"
   glue_crawler_error_metric_name           = "glue-crawler-error"


### PR DESCRIPTION
# Summary
Add anomaly detection alarms for all nightly ETLs run against the `Platform / GC Forms` datasets and a sampling of `Platform / GC Notify` datasets.

## ℹ️  Notes
1. These alarms will only be created in Prod.
2. This PR should merge after the Release Please setup PR has merged:
   - #250

# Related
- https://github.com/cds-snc/platform-core-services/issues/691