### PR TITLE
feat: publish Freshdesk ETL CloudWatch metrics

### DIFF
--- a/terragrunt/aws/glue/etl/platform/support/freshdesk/requirements.txt
+++ b/terragrunt/aws/glue/etl/platform/support/freshdesk/requirements.txt
@@ -1,2 +1,3 @@
 awswrangler==3.11.0
+boto3==1.38.15
 pandas==2.2.3


### PR DESCRIPTION
# Summary
Add CloudWatch metrics for the Freshdesk ETL.  These will be used by the CloudWatch anomaly detection alarms.

# Related
- https://github.com/cds-snc/platform-core-services/issues/691