### PR TITLE
chore: enable anomaly detection alarm actions

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -102,6 +102,9 @@ resource "aws_cloudwatch_metric_alarm" "anomaly_detection" {
   evaluation_periods  = 1
   treat_missing_data  = "notBreaching"
 
+  alarm_actions = [aws_sns_topic.cloudwatch_alarm_action.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_ok_action.arn]
+
   metric_query {
     id          = "expected_value"
     expression  = "ANOMALY_DETECTION_BAND(actual_value, ${each.value.standard_deviation})"


### PR DESCRIPTION
# Summary
Enable the anomaly detection alarm actions so that we will get notified in Slack if one is triggered.

## ℹ️ Note
These alarms are only created in Prod, so no Terraform plan is expected for this PR.

# Related
- https://github.com/cds-snc/platform-core-services/issues/691