### PR TITLE
fix: delay Notify ETL by 3 hours after RDS export

### DIFF
--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -136,7 +136,7 @@ resource "aws_glue_job" "platform_gc_notify_job" {
 
 resource "aws_glue_trigger" "platform_gc_notify_job" {
   name     = "Platform / GC Notify"
-  schedule = "cron(0 5 * * ? *)" # Daily at 5am UTC
+  schedule = "cron(0 7 * * ? *)" # Daily at 7am UTC
   type     = "SCHEDULED"
   enabled  = local.is_production
 


### PR DESCRIPTION
# Summary
Update the Notify ETL job to start 3 hours after the RDS export has started. This is being done because we caught an error today where the export had not finished in the current 1 hour gap between export and ETL.