### PR TITLE
fix: increase the look back days for the `notification_history` load

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - "terragrunt/aws/**"
-      - "!terragrunt/aws/glue/etl/**/*.json"
       - "terragrunt/env/staging/**"
       - "terragrunt/env/common/**"
       - "terragrunt/env/root.hcl"

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - "terragrunt/aws/**"
-      - "!terragrunt/aws/glue/etl/**/*.json"
       - "terragrunt/env/staging/**"
       - "terragrunt/env/common/**"
       - "terragrunt/env/root.hcl"

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -288,15 +288,15 @@ def download_s3_object(s3, s3_url, filename):
     )
 
 
-def get_incremental_load_date_from(data_retention_days: int) -> str:
+def get_incremental_load_date_from(data_look_back_days: int) -> str:
     """
     Get the date from which to load incremental data.  This will always be the beginning of
-    the month that is today minus the retention days.  The reason for this is because we
+    the month that is today minus the look back days.  The reason for this is because we
     perform a month partition overwrite and need to make sure that we are loading
     all data within the overwritten month partition(s) while respecting the data retention policy.
     """
     today = pd.Timestamp.now().normalize()
-    month_start = (today - pd.DateOffset(days=data_retention_days)).replace(day=1)
+    month_start = (today - pd.DateOffset(days=data_look_back_days)).replace(day=1)
     return month_start.strftime("%Y-%m-%d %H:%M:%S")
 
 
@@ -321,7 +321,7 @@ def process_data():
         path = f"{path_prefix}{table_name}"
         partition_cols = dataset.get("partition_cols")
         incremental_load = dataset.get("incremental_load", False)
-        retention_days = dataset.get("retention_days", 0)
+        look_back_days = dataset.get("look_back_days", 0)
 
         # Retrieve the new data
         logger.info(f"Processing {table_name} data...")
@@ -331,7 +331,7 @@ def process_data():
             dataset.get("partition_timestamp"),
             partition_cols,
             date_from=(
-                get_incremental_load_date_from(retention_days)
+                get_incremental_load_date_from(look_back_days)
                 if incremental_load
                 else None
             ),

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
@@ -111,7 +111,7 @@ def sample_dataset_config():
                 {"name": "status", "type": "text"},
             ],
             "incremental_load": True,
-            "retention_days": 90,
+            "look_back_days": 90,
         },
         {
             "table_name": "templates",
@@ -123,7 +123,7 @@ def sample_dataset_config():
                 {"name": "created_at", "type": "timestamp"},
             ],
             "incremental_load": False,
-            "retention_days": 0,
+            "look_back_days": 0,
         },
     ]
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
@@ -3,7 +3,7 @@
   "partition_timestamp": "created_at",
   "partition_cols": ["year", "month"],
   "incremental_load": true,
-  "retention_days": 14,
+  "look_back_days": 14,
   "fields": [
     {
       "name": "id",

--- a/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
@@ -3,7 +3,7 @@
   "partition_timestamp": "created_at",
   "partition_cols": ["year", "month"],
   "incremental_load": true,
-  "retention_days": 7,
+  "retention_days": 14,
   "fields": [
     {
       "name": "id",


### PR DESCRIPTION
# Summary
Double the amount of days the incremental load looks back and reloads month partitions for.  This is being done because we noticed that on May 8/9, new records on April 29/30 were in the `notification_history` table, but missed as the retention period of 7 days would only have loaded the May data.

This PR also updates the `retention_days` config to `look_back_days` to be more inline with how this value is treated for the data load.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/740