### PR TITLE
fix: added notificationinterval field

### DIFF
--- a/docs/data/catalog/platform/gc-forms/templates.md
+++ b/docs/data/catalog/platform/gc-forms/templates.md
@@ -113,6 +113,7 @@ Here's a descriptive list of the fields in each table:
 | titleen | string | Template title in English |
 | titlefr | string | Template title in French |
 | brand | string | Branding used by the template |
+| notificationsinterval | double | Interval between notifications in minutes |
 | addresscomplete_count | integer | Count of address complete elements |
 | checkbox_count | integer | Count of checkbox form elements |
 | combobox_count | integer | Count of combobox form elements |

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -124,7 +124,8 @@ def get_new_data(
     """
     data = pd.DataFrame()
     try:
-        yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
+        # yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
+        yesterday = pd.Timestamp("2025-05-15T00:00:00Z")  # hardcoded value for one off testing
         logger.info(
             f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3 from {yesterday}..."
         )
@@ -279,15 +280,20 @@ def process_data():
 
         # Retreive the new data
         logger.info(f"Processing {path} data...")
-        data = get_new_data(
-            path=path,
-            date_columns=date_columns,
-            drop_columns=drop_columns,
-            email_columns=email_columns,
-            field_count_columns=field_count_columns,
-            partition_columns=partition_columns,
-            partition_timestamp=partition_timestamp,
-        )
+        try:
+            data = get_new_data(
+                path=path,
+                date_columns=date_columns,
+                drop_columns=drop_columns,
+                email_columns=email_columns,
+                field_count_columns=field_count_columns,
+                partition_columns=partition_columns,
+                partition_timestamp=partition_timestamp,
+            )
+        except Exception as e:
+            logger.error(f"Failed to process {path}: {e}")
+            continue  
+
         if not data.empty:
             glue_table_schema = wr.catalog.table(
                 database=DATABASE_NAME_RAW,


### PR DESCRIPTION
# Summary | Résumé

Added notificationinterval field in the ETL process

# Test instructions | Instructions pour tester la modification

1.  Audit staging environment updated glue table schemas
     - platform_gc_forms_raw_template  
     - platform_gc_forms_template
2. Run the updated Platform / GC Forms glue job in staging environment
3. In Athena, ensure that the platform_gc_forms_template and platform_gc_forms_raw_template tables contains data for may 20th 
4. Ensure the above tables include the notificationinterval column
5. Ensure older data have null values for the notificationinterval column, and more recent data is populated
6. Manually edit glue schemas of the two tables in prod environment (copy staging schema)
8. **Important**, the current setup will process data from 2025-05-15 and onwards. This must crucially be reversed after the first run to avoid duplicate data  terragrunt/aws/glue/etl/platform/gc_forms/process_data.py l128
