### PR TITLE
Forms shema update rollback

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -218,8 +218,8 @@ def process_data():
             "email_columns": ["client_email"],
         },
         {
-           "path": "processed-data/submissions",
-           "date_columns": ["timestamp"],
+            "path": "processed-data/submissions",
+            "date_columns": ["timestamp"],
         },
         {
             "path": "processed-data/template",

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -124,10 +124,8 @@ def get_new_data(
     """
     data = pd.DataFrame()
     try:
-        # yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
-        yesterday = pd.Timestamp(
-            "2025-05-15T00:00:00Z"
-        )  # hardcoded value for one off testing
+        yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
+
         logger.info(
             f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3 from {yesterday}..."
         )
@@ -219,10 +217,10 @@ def process_data():
             "partition_columns": ["year", "month"],
             "email_columns": ["client_email"],
         },
-        # {
-        #    "path": "processed-data/submissions",
-        #    "date_columns": ["timestamp"],
-        # },
+        {
+           "path": "processed-data/submissions",
+           "date_columns": ["timestamp"],
+        },
         {
             "path": "processed-data/template",
             "date_columns": [

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
@@ -180,10 +180,10 @@ def test_publish_metric(mock_logger, mock_datetime):
 def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
     # Mock AWS Wrangler response
     mock_wr_s3.read_parquet.return_value = sample_data_df
-    # fixed_date = datetime(1970, 1, 2)
-    # fixed_date_yesterday = datetime(1970, 1, 1)
-    # mock_timestamp.today.return_value = fixed_date
-    hardcoded_date = pd.Timestamp("2025-05-15T00:00:00Z")
+    fixed_date = datetime(1970, 1, 2)
+    fixed_date_yesterday = datetime(1970, 1, 1)
+    mock_timestamp.today.return_value = fixed_date
+
 
     result = get_new_data(
         path="test-path",
@@ -200,7 +200,7 @@ def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
         path=f"s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/test-path/",
         use_threads=True,
         dataset=True,
-        last_modified_begin=hardcoded_date,
+        last_modified_begin=fixed_date_yesterday,
     )
 
     # Verify data is processed correctly
@@ -261,9 +261,9 @@ def test_process_data(
     process_data()
 
     # Verify a call for each dataset
-    assert mock_get_new_data.call_count == 4
-    assert mock_wr_s3.to_parquet.call_count == 4
-    assert mock_cloudwatch.put_metric_data.call_count == 4
+    assert mock_get_new_data.call_count == 5
+    assert mock_wr_s3.to_parquet.call_count == 5
+    assert mock_cloudwatch.put_metric_data.call_count == 5
 
 
 @patch("process_data.get_new_data")
@@ -281,7 +281,7 @@ def test_process_data_empty_dataset(
     process_data()
 
     mock_wr_s3.to_parquet.assert_not_called()
-    assert mock_cloudwatch.put_metric_data.call_count == 4
+    assert mock_cloudwatch.put_metric_data.call_count == 5
 
 
 @patch("process_data.get_new_data")

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
@@ -184,7 +184,6 @@ def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
     fixed_date_yesterday = datetime(1970, 1, 1)
     mock_timestamp.today.return_value = fixed_date
 
-
     result = get_new_data(
         path="test-path",
         date_columns=["date", "timestamp", "created_at"],


### PR DESCRIPTION
# Summary | Résumé

Rolling back one-time changes for the notificationinterval field.

Keeping updated schema, and job continuation when one table fails




