### PR TITLE
fix: CloudWatch metric filter alarms for ETL jobs

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -34,13 +34,13 @@ resource "aws_cloudwatch_metric_alarm" "glue_crawler_error" {
 #
 # Glue ETL errors
 #
-resource "aws_cloudwatch_log_metric_filter" "glue_etl_error" {
-  name           = "glue-etl-error"
-  pattern        = local.glue_etl_metric_filter_error_pattern
-  log_group_name = "${var.glue_etl_log_group_name}/output"
+resource "aws_cloudwatch_log_metric_filter" "glue_etl_pythonshell_error" {
+  name           = "glue-etl-pythonshell-error"
+  pattern        = local.glue_etl_pythonshell_metric_filter_error_pattern
+  log_group_name = "${var.glue_etl_pythonshell_log_group_name}/error"
 
   metric_transformation {
-    name          = local.glue_etl_error_metric_name
+    name          = local.glue_etl_pythonshell_error_metric_name
     namespace     = local.data_lake_namespace
     value         = "1"
     default_value = "0"
@@ -48,13 +48,43 @@ resource "aws_cloudwatch_log_metric_filter" "glue_etl_error" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "glue_etl_error" {
-  alarm_name          = "glue-etl-error"
-  alarm_description   = "Errors logged over 1 minute by a Glue ETL job."
+resource "aws_cloudwatch_log_metric_filter" "glue_etl_spark_error" {
+  name           = "glue-etl-spark-error"
+  pattern        = local.glue_etl_spark_metric_filter_error_pattern
+  log_group_name = "${var.glue_etl_spark_log_group_name}/error"
+
+  metric_transformation {
+    name          = local.glue_etl_spark_error_metric_name
+    namespace     = local.data_lake_namespace
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "glue_etl_pythonshell_error" {
+  alarm_name          = "glue-etl-pythonshell-error"
+  alarm_description   = "Errors logged over 1 minute by a Glue ETL pythonshell job."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.glue_etl_error.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.glue_etl_error.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.glue_etl_pythonshell_error.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.glue_etl_pythonshell_error.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alarm_action.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_ok_action.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "glue_etl_spark_error" {
+  alarm_name          = "glue-etl-spark-error"
+  alarm_description   = "Errors logged over 1 minute by a Glue ETL spark job."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.glue_etl_spark_error.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.glue_etl_spark_error.metric_transformation[0].namespace
   period              = "60"
   statistic           = "Sum"
   threshold           = "0"

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -2,6 +2,9 @@ locals {
   data_lake_namespace                      = "data-lake"
   glue_crawler_metric_filter_error_pattern = "ERROR"
   glue_crawler_error_metric_name           = "glue-crawler-error"
-  glue_etl_metric_filter_error_pattern     = "ERROR"
-  glue_etl_error_metric_name               = "glue-etl-error"
+
+  glue_etl_pythonshell_error_metric_name           = "glue-etl-pythonshell-error"
+  glue_etl_pythonshell_metric_filter_error_pattern = "ERROR"
+  glue_etl_spark_error_metric_name                 = "glue-etl-spark-error"
+  glue_etl_spark_metric_filter_error_pattern       = "[(w1=\"*ERROR*com.amazonaws.services.glue.log.GlueLogger*\")]"
 }

--- a/terragrunt/aws/alarms/variables.tf
+++ b/terragrunt/aws/alarms/variables.tf
@@ -9,7 +9,12 @@ variable "glue_crawler_log_group_name" {
   type        = string
 }
 
-variable "glue_etl_log_group_name" {
-  description = "The name of the Glue ETL CloudWatch log group."
+variable "glue_etl_pythonshell_log_group_name" {
+  description = "The name of the Glue ETL CloudWatch log group used by `pythonshell` jobs."
+  type        = string
+}
+
+variable "glue_etl_spark_log_group_name" {
+  description = "The name of the Glue ETL CloudWatch log group used by `spark` jobs."
   type        = string
 }

--- a/terragrunt/aws/glue/locals.tf
+++ b/terragrunt/aws/glue/locals.tf
@@ -21,6 +21,7 @@ locals {
     ]) > 0
   ])
 
-  glue_crawler_log_group_name = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"
-  glue_etl_log_group_name     = "/aws-glue/jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"
+  glue_crawler_log_group_name         = "/aws-glue/crawlers-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_crawler.name}-${aws_glue_security_configuration.encryption_at_rest.name}"
+  glue_etl_pythonshell_log_group_name = "/aws-glue/python-jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"
+  glue_etl_spark_log_group_name       = "/aws-glue/jobs/${aws_glue_security_configuration.encryption_at_rest.name}-role${aws_iam_role.glue_crawler.path}${aws_iam_role.glue_etl.name}"
 }

--- a/terragrunt/aws/glue/outputs.tf
+++ b/terragrunt/aws/glue/outputs.tf
@@ -3,7 +3,12 @@ output "glue_crawler_log_group_name" {
   value       = local.glue_crawler_log_group_name
 }
 
-output "glue_etl_log_group_name" {
-  description = "The name of the Glue ETL CloudWatch log group."
-  value       = local.glue_etl_log_group_name
+output "glue_etl_pythonshell_log_group_name" {
+  description = "The name of the Glue ETL CloudWatch log group used by `pythonshell` Glue jobs."
+  value       = local.glue_etl_pythonshell_log_group_name
+}
+
+output "glue_etl_spark_log_group_name" {
+  description = "The name of the Glue ETL CloudWatch log group used by `spark` Glue jobs."
+  value       = local.glue_etl_spark_log_group_name
 }

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -11,14 +11,16 @@ dependency "glue" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    glue_crawler_log_group_name = "mock-glue-crawler-log-group"
-    glue_etl_log_group_name     = "mock-glue-etl-log-group"
+    glue_crawler_log_group_name         = "mock-glue-crawler-log-group"
+    glue_etl_pythonshell_log_group_name = "mock-glue-etl-pythonshell-log-group"
+    glue_etl_spark_log_group_name       = "mock-glue-etl-spark-log-group"
   }
 }
 
 inputs = {
-  glue_crawler_log_group_name = dependency.glue.outputs.glue_crawler_log_group_name
-  glue_etl_log_group_name     = dependency.glue.outputs.glue_etl_log_group_name
+  glue_crawler_log_group_name         = dependency.glue.outputs.glue_crawler_log_group_name
+  glue_etl_pythonshell_log_group_name = dependency.glue.outputs.glue_etl_pythonshell_log_group_name
+  glue_etl_spark_log_group_name       = dependency.glue.outputs.glue_etl_spark_log_group_name
 }
 
 include {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -11,14 +11,16 @@ dependency "glue" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    glue_crawler_log_group_name = "mock-glue-crawler-log-group"
-    glue_etl_log_group_name     = "mock-glue-etl-log-group"
+    glue_crawler_log_group_name         = "mock-glue-crawler-log-group"
+    glue_etl_pythonshell_log_group_name = "mock-glue-etl-pythonshell-log-group"
+    glue_etl_spark_log_group_name       = "mock-glue-etl-spark-log-group"
   }
 }
 
 inputs = {
-  glue_crawler_log_group_name = dependency.glue.outputs.glue_crawler_log_group_name
-  glue_etl_log_group_name     = dependency.glue.outputs.glue_etl_log_group_name
+  glue_crawler_log_group_name         = dependency.glue.outputs.glue_crawler_log_group_name
+  glue_etl_pythonshell_log_group_name = dependency.glue.outputs.glue_etl_pythonshell_log_group_name
+  glue_etl_spark_log_group_name       = dependency.glue.outputs.glue_etl_spark_log_group_name
 }
 
 include {


### PR DESCRIPTION
# Summary
Update the CloudWatch metric filters and alarms so that they properly catch `ERROR` logs in the log groups for both Spark and Pythonshell ETL job types.

⚠️ Note that it is expected that this PR will destroy the existing `glue_etl_error` CloudWatch metric filter and alarm.