### PR TITLE
fix: skip missing Forms historical data error alarms

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -113,19 +113,3 @@ resource "aws_cloudwatch_metric_alarm" "glue_job_failures" {
     RuleName = aws_cloudwatch_event_rule.glue_job_failure.name
   }
 }
-
-#
-# Log Insight queries
-#
-resource "aws_cloudwatch_query_definition" "glue_crawler_errors" {
-  name = "Glue Crawler - ERRORS"
-
-  log_group_names = [var.glue_crawler_log_group_name]
-
-  query_string = <<-QUERY
-    fields @timestamp, @message, @logStream
-    | filter @message like /${local.glue_crawler_metric_filter_error_pattern}/
-    | sort @timestamp desc
-    | limit 100
-  QUERY
-}

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -4,7 +4,10 @@ locals {
   glue_crawler_error_metric_name           = "glue-crawler-error"
 
   glue_etl_pythonshell_error_metric_name           = "glue-etl-pythonshell-error"
-  glue_etl_pythonshell_metric_filter_error_pattern = "ERROR"
-  glue_etl_spark_error_metric_name                 = "glue-etl-spark-error"
-  glue_etl_spark_metric_filter_error_pattern       = "[(w1=\"*ERROR*com.amazonaws.services.glue.log.GlueLogger*\")]"
+  glue_etl_pythonshell_metric_filters              = ["ERROR"]
+  glue_etl_pythonshell_metric_filters_skip         = ["No new historical-data data found."]
+  glue_etl_pythonshell_metric_filter_error_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.glue_etl_pythonshell_metric_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.glue_etl_pythonshell_metric_filters_skip)}*\"]"
+
+  glue_etl_spark_error_metric_name           = "glue-etl-spark-error"
+  glue_etl_spark_metric_filter_error_pattern = "[(w1=\"*ERROR*com.amazonaws.services.glue.log.GlueLogger*\")]"
 }

--- a/terragrunt/aws/alarms/logs.tf
+++ b/terragrunt/aws/alarms/logs.tf
@@ -1,0 +1,41 @@
+#
+# Log Insight queries
+#
+resource "aws_cloudwatch_query_definition" "glue_crawler_errors" {
+  name = "Glue Crawler - ERRORS"
+
+  log_group_names = [var.glue_crawler_log_group_name]
+
+  query_string = <<-QUERY
+    fields @timestamp, @message, @logStream
+    | filter @message like /${local.glue_crawler_metric_filter_error_pattern}/
+    | sort @timestamp desc
+    | limit 100
+  QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "glue_etl_pythonshell_errors" {
+  name = "Glue ETL pythonshell - ERRORS"
+
+  log_group_names = ["${var.glue_etl_pythonshell_log_group_name}/error"]
+
+  query_string = <<-QUERY
+    fields @timestamp, @message, @logStream
+    | filter @message like /ERROR/
+    | sort @timestamp desc
+    | limit 100
+  QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "glue_etl_spark_errors" {
+  name = "Glue ETL spark - ERRORS"
+
+  log_group_names = ["${var.glue_etl_spark_log_group_name}/error"]
+
+  query_string = <<-QUERY
+    fields @timestamp, @message, @logStream
+    | filter @message like /ERROR/
+    | sort @timestamp desc
+    | limit 100
+  QUERY
+}


### PR DESCRIPTION
# Summary
Update the `pythonshell` CloudWatch alarm so that it does not trigger for missing GC Forms historical data.

Add saved Log Insight queries to make it easier to troubleshoot alarms.