### PR TITLE
fix: Missing terraform output statement

### DIFF
--- a/terragrunt/aws/buckets/outputs.tf
+++ b/terragrunt/aws/buckets/outputs.tf
@@ -28,6 +28,16 @@ output "glue_bucket_name" {
   value       = module.glue_bucket.s3_bucket_id
 }
 
+output "gx_bucket_arn" {
+  description = "ARN of the S3 GX data bucket."
+  value       = module.gx_bucket.s3_bucket_arn
+}
+
+output "gx_bucket_name" {
+  description = "Name of the S3 GX data bucket."
+  value       = module.gx_bucket.s3_bucket_id
+}
+
 output "raw_bucket_arn" {
   description = "ARN of the S3 Raw data bucket."
   value       = module.raw_bucket.s3_bucket_arn


### PR DESCRIPTION
# Summary | Résumé

Forgot to add a terraform output statement - terraform succeeded because it used the mocked values that were properly setup

