### PR TITLE
feat: add Notify dataset anomaly detection

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -211,8 +211,12 @@ def get_new_data(
 
 
 def publish_metric(
-    cloudwatch, metric_namespace, metric_name, dataset_name, metric_value
-):
+    cloudwatch: boto3.client,
+    metric_namespace: str,
+    metric_name: str,
+    dataset_name: str,
+    metric_value: float,
+) -> None:
     """
     Publish data processing metrics to CloudWatch
     """
@@ -233,7 +237,16 @@ def publish_metric(
     )
 
 
-def get_metrics(cloudwatch, metric_namespace, metric_name, dataset_name, days):
+def get_metrics(
+    cloudwatch: boto3.client,
+    metric_namespace: str,
+    metric_name: str,
+    dataset_name: str,
+    days: int,
+) -> np.ndarray:
+    """
+    Retrieve historical metrics from CloudWatch for a specific dataset.
+    """
     end_time = datetime.now(timezone.utc)
     start_time = end_time - timedelta(days=days)
 
@@ -303,7 +316,7 @@ def get_dataset_config():
     return datasets
 
 
-def download_s3_object(s3, s3_url, filename):
+def download_s3_object(s3: boto3.client, s3_url: str, filename: str) -> None:
     """
     Download an S3 object to a local file.
     """
@@ -316,7 +329,9 @@ def download_s3_object(s3, s3_url, filename):
     )
 
 
-def detect_anomalies(row_count, historical_data, standard_deviation_threshold):
+def detect_anomalies(
+    row_count: int, historical_data: np.ndarray, standard_deviation_threshold: float
+) -> bool:
     """
     Detect anomalies by checking if the latest value falls within
     a certain number of standard deviations from the mean.

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -253,9 +253,7 @@ def get_metrics(cloudwatch, metric_namespace, metric_name, dataset_name, days):
         values = [point["Maximum"] for point in datapoints]
         metrics = np.array(values)
 
-        logger.info(
-            f"Retrieved {metrics} metrics for {dataset_name} from CloudWatch."
-        )
+        logger.info(f"Retrieved {metrics} metrics for {dataset_name} from CloudWatch.")
         return metrics
 
     except Exception as e:
@@ -323,6 +321,10 @@ def detect_anomalies(row_count, historical_data, standard_deviation_threshold):
     Detect anomalies by checking if the latest value falls within
     a certain number of standard deviations from the mean.
     """
+    if historical_data is None or len(historical_data) == 0:
+        logger.error("No historical data available for anomaly detection.")
+        return False
+
     mean = np.mean(historical_data)
     standard_deviation = np.std(historical_data, ddof=1)
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -1,14 +1,14 @@
 import json
 import os
 import sys
-import time
 import zipfile
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, TypedDict
 
 import awswrangler as wr
 import boto3
+import numpy as np
 import pandas as pd
 import pyarrow.dataset as ds
 
@@ -42,6 +42,12 @@ DATABASE_NAME_TRANSFORMED = args["database_name_transformed"]
 TABLE_CONFIG_OBJECT = args["table_config_object"]
 TABLE_NAME_PREFIX = args["table_name_prefix"]
 TARGET_ENV = args["target_env"]
+
+# Anomaly detection configuration
+METRIC_NAMESPACE = "data-lake/etl/gc-notify"
+METRIC_NAME = "ProcessedRecordCount"
+ANOMALY_LOOKBACK_DAYS = 14
+ANOMALY_STANDARD_DEVIATION = 2.0
 
 glueContext = GlueContext(SparkContext.getOrCreate())
 logger = glueContext.get_logger()
@@ -204,33 +210,57 @@ def get_new_data(
     return data
 
 
-def publish_metric(cloudwatch, dataset_name, count, processing_time):
+def publish_metric(
+    cloudwatch, metric_namespace, metric_name, dataset_name, metric_value
+):
     """
     Publish data processing metrics to CloudWatch
     """
-    timestamp = datetime.now(timezone.utc)
     cloudwatch.put_metric_data(
-        Namespace="data-lake/etl/gc-notify",
+        Namespace=metric_namespace,
         MetricData=[
             {
-                "MetricName": "ProcessedRecordCount",
+                "MetricName": metric_name,
                 "Dimensions": [{"Name": "Dataset", "Value": dataset_name}],
-                "Value": count,
-                "Timestamp": timestamp,
+                "Value": metric_value,
+                "Timestamp": datetime.now(timezone.utc),
                 "Unit": "Count",
-            },
-            {
-                "MetricName": "ProcessingTime",
-                "Dimensions": [{"Name": "Dataset", "Value": dataset_name}],
-                "Value": processing_time,
-                "Timestamp": timestamp,
-                "Unit": "Seconds",
             },
         ],
     )
     logger.info(
-        f"Published metrics for {dataset_name}: {count} records in {processing_time:.2f}s"
+        f"Published metrics for {dataset_name}: {metric_value} records processed"
     )
+
+
+def get_metrics(cloudwatch, metric_namespace, metric_name, dataset_name, days):
+    end_time = datetime.now(timezone.utc)
+    start_time = end_time - timedelta(days=days)
+
+    try:
+        response = cloudwatch.get_metric_statistics(
+            Namespace=metric_namespace,
+            MetricName=metric_name,
+            Dimensions=[{"Name": "Dataset", "Value": dataset_name}],
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=86400,  # 1 day
+            Statistics=["Maximum"],
+        )
+
+        # Sort by timestamp and extract values
+        datapoints = sorted(response["Datapoints"], key=lambda x: x["Timestamp"])
+        values = [point["Maximum"] for point in datapoints]
+        metrics = np.array(values)
+
+        logger.info(
+            f"Retrieved {metrics} metrics for {dataset_name} from CloudWatch."
+        )
+        return metrics
+
+    except Exception as e:
+        logger.error(f"Error fetching CloudWatch metric data: {e}")
+        return None
 
 
 def get_dataset_config():
@@ -288,6 +318,27 @@ def download_s3_object(s3, s3_url, filename):
     )
 
 
+def detect_anomalies(row_count, historical_data, standard_deviation_threshold):
+    """
+    Detect anomalies by checking if the latest value falls within
+    a certain number of standard deviations from the mean.
+    """
+    mean = np.mean(historical_data)
+    standard_deviation = np.std(historical_data, ddof=1)
+
+    z_score = 0
+    if standard_deviation != 0:
+        z_score = (row_count - mean) / standard_deviation
+
+    is_anomaly = abs(z_score) > standard_deviation_threshold
+    if is_anomaly:
+        logger.error(
+            f"Anomaly: Latest value {row_count}, mean: {mean:.2f}, "
+            f"stdev: {standard_deviation:.2f}, z_score: {z_score:.2f}"
+        )
+    return is_anomaly
+
+
 def get_incremental_load_date_from(data_look_back_days: int) -> str:
     """
     Get the date from which to load incremental data.  This will always be the beginning of
@@ -316,7 +367,6 @@ def process_data():
     # Read the dataset configuration and start processing
     datasets = get_dataset_config()
     for dataset in datasets:
-        start_time = time.time()
         table_name = dataset.get("table_name")
         path = f"{path_prefix}{table_name}"
         partition_cols = dataset.get("partition_cols")
@@ -359,9 +409,19 @@ def process_data():
         else:
             logger.error(f"No new {table_name} data found.")
 
-        # Publish metrics to CloudWatch
-        processing_time = time.time() - start_time
-        publish_metric(cloudwatch, table_name, len(data), processing_time)
+        # Check for anomalies in rows of data processed
+        # by comparing with previous data processed metrics
+        historical_data = get_metrics(
+            cloudwatch,
+            METRIC_NAMESPACE,
+            METRIC_NAME,
+            table_name,
+            ANOMALY_LOOKBACK_DAYS,
+        )
+
+        row_count = len(data)
+        detect_anomalies(row_count, historical_data, ANOMALY_STANDARD_DEVIATION)
+        publish_metric(cloudwatch, METRIC_NAMESPACE, METRIC_NAME, table_name, row_count)
 
     logger.info("ETL process completed successfully.")
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/requirements_dev.txt
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/requirements_dev.txt
@@ -1,3 +1,4 @@
 black==25.1.0
 flake8==7.2.0
+pandas==2.2.3
 pytest==8.3.5

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "glue_etl_combined" {
     data.aws_iam_policy_document.s3_write_data_lake.json,
     data.aws_iam_policy_document.glue_kms.json,
     data.aws_iam_policy_document.gc_notify_rds_export_kms.json,
-    data.aws_iam_policy_document.cloudwatch_put_metrics.json
+    data.aws_iam_policy_document.cloudwatch_metrics.json
   ]
 }
 
@@ -210,12 +210,14 @@ data "aws_iam_policy_document" "s3_write_data_lake" {
   }
 }
 
-data "aws_iam_policy_document" "cloudwatch_put_metrics" {
+data "aws_iam_policy_document" "cloudwatch_metrics" {
   statement {
-    sid    = "PutCloudWatchMetrics"
+    sid    = "CloudWatchMetrics"
     effect = "Allow"
     actions = [
-      "cloudwatch:PutMetricData"
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:PutMetricData",
     ]
     resources = [
       "*" # Only wildcard is allowed for this action


### PR DESCRIPTION
# Summary
Check that for each table processed in the Notify dataset, the number of rows is within 2 standard deviations from the mean number of rows processed over the past 2 weeks.

If the number of rows processed is anomalous, the error log will trigger a CloudWatch metric alarm.

# Related
- https://github.com/cds-snc/platform-core-services/issues/691