### PR TITLE
feat: write site-docs to s3 bucket

### DIFF
--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -59,6 +59,7 @@ resource "aws_glue_job" "platform_gc_forms_job" {
     "--database_name_raw"                = aws_glue_catalog_database.platform_gc_forms_production_raw.name
     "--database_name_transformed"        = aws_glue_catalog_database.platform_gc_forms_production.name
     "--table_name_prefix"                = "platform_gc_forms"
+    "--target_gx_bucket"                 = gx_bucket_name
   }
 }
 

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
@@ -20,6 +20,7 @@ mock_args = {
     "database_name_transformed": "test_transformed_db",
     "table_name_prefix": "test_table",
     "gx_config_object": "s3://test-config-bucket/test-config-key",
+    "target_gx_bucket": "",
 }
 
 # Mock the AWS Glue and PySpark modules
@@ -34,6 +35,7 @@ from process_data import (
     get_new_data,
     process_data,
     publish_metric,
+    configure_data_docs_site,
     SOURCE_BUCKET,
     SOURCE_PREFIX,
 )
@@ -623,3 +625,73 @@ def test_process_data_validation_failure_great_expectations_bad_schema_str_count
     assert mock_get_new_data.call_count == 1
     assert mock_wr_s3.to_parquet.call_count == 0
     assert mock_cloudwatch.put_metric_data.call_count == 0
+
+
+@patch("process_data.configure_data_docs_site")  # Add this patch
+@patch("process_data.download_s3_object")
+@patch("process_data.get_new_data")
+@patch("awswrangler.catalog")
+@patch("awswrangler.s3")
+@patch("boto3.client")
+def test_process_data_sitedocs_s3_write_attempt(
+    mock_boto3_client,
+    mock_wr_s3,
+    mock_wr_catalog,
+    mock_get_new_data,
+    mock_s3,
+    mock_update_config,
+    sample_data_df,
+    glue_table_schema,
+):
+    # Setup basic mocks
+    mock_get_new_data.return_value = sample_data_df
+    mock_wr_catalog.table.return_value = glue_table_schema
+
+    # Force update_data_docs_site_config to use test-bucket
+    def update_config(yml_path, target_gx_bucket=None):
+        # Always use test-bucket regardless of input
+        return configure_data_docs_site(yml_path, "test-bucket")
+
+    mock_update_config.side_effect = update_config
+
+    s3_mock = Mock()
+    s3_mock.put_object.side_effect = Exception("Unable to locate credentials")
+    mock_boto3_client.return_value = s3_mock
+    # Run the process expecting the credentials error
+
+    with pytest.raises(Exception) as excinfo:
+        process_data(
+            datasets=[
+                {
+                    "path": "processed-data/template",
+                    "date_columns": [
+                        "ttl",
+                        "api_created_at",
+                        "timestamp",
+                        "closingdate",
+                        "created_at",
+                        "updated_at",
+                    ],
+                    "field_count_columns": [
+                        "checkbox_count",
+                        "combobox_count",
+                        "dropdown_count",
+                        "dynamicrow_count",
+                        "fileinput_count",
+                        "formatteddate_count",
+                        "radio_count",
+                        "richtext_count",
+                        "textarea_count",
+                        "textfield_count",
+                        "addresscomplete_count",
+                    ],
+                    "partition_timestamp": "created_at",
+                    "partition_columns": ["year", "month"],
+                    "email_columns": ["deliveryemaildestination"],
+                    "gx_checkpoint": "forms-template_checkpoint",
+                }
+            ]
+        )
+
+    # Verify the error message
+    assert "Unable to locate credentials" in str(excinfo.value)

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -133,7 +133,8 @@ data "aws_iam_policy_document" "s3_read_data_lake" {
       "${var.curated_bucket_arn}/*",
       "${var.glue_bucket_arn}/*",
       "${var.raw_bucket_arn}/*",
-      "${var.transformed_bucket_arn}/*"
+      "${var.transformed_bucket_arn}/*",
+      "${var.gx_bucket_arn}/*"
     ]
   }
 }
@@ -205,7 +206,8 @@ data "aws_iam_policy_document" "s3_write_data_lake" {
     resources = [
       "${var.curated_bucket_arn}/*",
       "${var.transformed_bucket_arn}/*",
-      "${var.raw_bucket_arn}/*"
+      "${var.raw_bucket_arn}/*",
+      "${var.gx_bucket_arn}/*"
     ]
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Saving GE outputs to the appropriate s3 bucket, which will be hosted as a static website


# Test instructions | Instructions pour tester la modification

1) run glue job
2) ensure output is saved to s3 bucket