### PR TITLE
chore: suppress pip dependency resolver errors

### DIFF
--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -5,7 +5,7 @@ locals {
 
   glue_etl_pythonshell_error_metric_name           = "glue-etl-pythonshell-error"
   glue_etl_pythonshell_metric_filters              = ["ERROR"]
-  glue_etl_pythonshell_metric_filters_skip         = ["No new historical-data data found."]
+  glue_etl_pythonshell_metric_filters_skip         = ["No new historical-data data found.", "pip's dependency resolver"]
   glue_etl_pythonshell_metric_filter_error_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.glue_etl_pythonshell_metric_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.glue_etl_pythonshell_metric_filters_skip)}*\"]"
 
   glue_etl_spark_error_metric_name           = "glue-etl-spark-error"


### PR DESCRIPTION
# Summary
Do not trigger a CloudWatch alarm for pip dependency resolver errors.  These occur because of how Glue jobs install user specified dependencies.