### PR TITLE
fix: increased notify timeout

### DIFF
--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -130,7 +130,7 @@ resource "aws_glue_job" "platform_gc_notify_job" {
   name = "Platform / GC Notify"
 
   glue_version           = "5.0"
-  timeout                = 30 # minutes
+  timeout                = 90 # minutes
   role_arn               = aws_iam_role.glue_etl.arn
   security_configuration = aws_glue_security_configuration.encryption_at_rest.name
   worker_type            = "G.2X"


### PR DESCRIPTION
# Summary | Résumé

Data validation performs operations on the data, longer processing time is therefore expected. It took 30mns to run the job in staging instead of the previous 10 minutes.

Also, I noticed that even though we use a spark job, the data is loaded in Pandas meaning that we can't use parallelism.

A 30 mn daily job is still acceptable, but we should eventually switch to Spark DataFrames



# Test instructions | Instructions pour tester la modification

Ensure timeout value is updated
