### PR TITLE
fix: undo day partitioning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "version": "3.13"
     },
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.1",
+      "version": "1.12.1",
       "terragrunt": "0.68.6"
     }
   },

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -27,8 +27,6 @@ args = getResolvedOptions(
         "database_name_transformed",
         "table_name_prefix",
         "gx_config_object",
-        "first_date",
-        "last_date",
     ],
 )
 
@@ -37,13 +35,11 @@ SOURCE_PREFIX = args["source_prefix"]
 TRANSFORMED_BUCKET = args["transformed_bucket"]
 TRANSFORMED_PREFIX = args["transformed_prefix"]
 TRANSFORMED_PATH = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}"
+PARTITION_KEY = "month"
 DATABASE_NAME_RAW = args["database_name_raw"]
 DATABASE_NAME_TRANSFORMED = args["database_name_transformed"]
 TABLE_NAME_PREFIX = args["table_name_prefix"]
 GX_CONFIG_OBJECT = args["gx_config_object"]
-FIRST_DATE = args.get("first_date", "yesterday").lower()
-LAST_DATE = args.get("last_date", "yesterday").lower()
-
 
 # Anomaly detection configuration
 METRIC_NAMESPACE = "data-lake/etl/gc-forms"
@@ -136,8 +132,6 @@ def get_new_data(
     field_count_columns: Optional[List[str]],
     partition_columns: Optional[List[str]],
     partition_timestamp: Optional[str],
-    first_date: str = FIRST_DATE,
-    last_date: str = LAST_DATE,
 ) -> pd.DataFrame:
     """
     Reads the data from the specified path in S3 and returns a DataFrame.
@@ -148,32 +142,16 @@ def get_new_data(
     """
     data = pd.DataFrame()
     try:
-
-        if first_date == "yesterday":
-            first_date = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=1)).strftime(
-                "%Y-%m-%d"
-            )
-        if last_date == "yesterday":
-            last_date = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=1)).strftime(
-                "%Y-%m-%d"
-            )
-
-        last_modified_begin = (
-            datetime.strptime(first_date, "%Y-%m-%d") - timedelta(days=1)
-        ).replace(tzinfo=timezone.utc)
-        last_modified_end = datetime.strptime(last_date, "%Y-%m-%d").replace(
-            tzinfo=timezone.utc
-        )
+        yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=1)
 
         logger.info(
-            f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3 from {last_modified_begin} to {last_modified_end}..."
+            f"Reading s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/ data from S3 from {yesterday}..."
         )
         data = wr.s3.read_parquet(
             path=f"s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/{path}/",
             use_threads=True,
             dataset=True,
-            last_modified_begin=last_modified_begin,
-            last_modified_end=last_modified_end,
+            last_modified_begin=yesterday,
         )
         data.columns = [col.lower() for col in data.columns]
 
@@ -204,17 +182,11 @@ def get_new_data(
             partition_format = {
                 "month": "%Y-%m",
                 "year": "%Y",
-                "day": "%Y-%m-%d",
             }
             for partition in partition_columns:
                 data[partition] = data[partition_timestamp].dt.strftime(
                     partition_format[partition]
                 )
-
-        logger.info(
-            f"Filtering for data timestamped between {first_date} and {last_date}..."
-        )
-        data = data.loc[(data["day"] >= first_date) & (data["day"] <= last_date)]
 
     except wr.exceptions.NoFilesFound:
         logger.error(f"No new {path} data found.")
@@ -319,7 +291,7 @@ def download_s3_object(s3: boto3.client, s3_url: str, filename: str) -> None:
     """
     bucket_name = s3_url.split("/")[2]
     object_key = "/".join(s3_url.split("/")[3:])
-    current_dir = os.path.dirname(__file__)
+    current_dir = os.getcwd()
     s3.download_file(
         Bucket=bucket_name,
         Key=object_key,
@@ -338,6 +310,7 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
     Main ETL process to read data from S3, validate the schema, and save the
     transformed data back to S3.
     """
+
     cloudwatch = boto3.client("cloudwatch")
     s3 = boto3.client("s3")
     download_s3_object(s3, GX_CONFIG_OBJECT, "gx.zip")
@@ -348,7 +321,7 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
                 "path": "historical-data",
                 "date_columns": ["date"],
                 "partition_timestamp": "date",
-                "partition_columns": ["year", "month", "day"],
+                "partition_columns": ["year", "month"],
                 "email_columns": ["client_email"],
                 "gx_checkpoint": "forms-historicaldata_checkpoint",
             },
@@ -356,7 +329,6 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
                 "path": "processed-data/submissions",
                 "date_columns": ["timestamp"],
                 "partition_timestamp": "timestamp",
-                "partition_columns": ["year", "month", "day"],
                 "gx_checkpoint": "forms-submissions_checkpoint",
             },
             {
@@ -383,7 +355,7 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
                     "addresscomplete_count",
                 ],
                 "partition_timestamp": "timestamp",
-                "partition_columns": ["year", "month", "day"],
+                "partition_columns": ["year", "month"],
                 "email_columns": ["deliveryemaildestination"],
                 "gx_checkpoint": "forms-template_checkpoint",
             },
@@ -392,7 +364,6 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
                 "date_columns": ["timestamp"],
                 "gx_checkpoint": "forms-templatetouser_checkpoint",
                 "partition_timestamp": "timestamp",
-                "partition_columns": ["year", "month", "day"],
             },
             {
                 "path": "processed-data/user",
@@ -403,7 +374,7 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
                     "timestamp",
                 ],
                 "partition_timestamp": "timestamp",
-                "partition_columns": ["year", "month", "day"],
+                "partition_columns": ["year", "month"],
                 "drop_columns": ["name"],
                 "email_columns": ["email"],
                 "gx_checkpoint": "forms-user_checkpoint",
@@ -415,6 +386,7 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
     cloudwatch = boto3.client("cloudwatch")
 
     for dataset in datasets:
+
         path = dataset.get("path")
         date_columns = dataset.get("date_columns")
         drop_columns = dataset.get("drop_columns")
@@ -457,7 +429,7 @@ def process_data(datasets: Optional[List[dict]] = None) -> None:
                 df=data,
                 path=f"{TRANSFORMED_PATH}/{path}/",
                 dataset=True,
-                mode="overwrite_partitions",
+                mode="append",
                 database=DATABASE_NAME_TRANSFORMED,
                 table=table,
                 partition_cols=partition_columns,

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
@@ -21,8 +21,6 @@ mock_args = {
     "database_name_transformed": "test_transformed_db",
     "table_name_prefix": "test_table",
     "gx_config_object": "s3://test-config-bucket/test-config-key",
-    "first_date": "yesterday",
-    "last_date": "yesterday",
 }
 
 # Mock the AWS Glue and PySpark modules
@@ -73,7 +71,7 @@ def datasets_params():
             "addresscomplete_count",
         ],
         "partition_timestamp": "timestamp",
-        "partition_columns": ["year", "month", "day"],
+        "partition_columns": ["year", "month"],
         "email_columns": ["deliveryemaildestination"],
         "gx_checkpoint": "forms-template_checkpoint",
     }
@@ -228,13 +226,9 @@ def test_publish_metric(mock_logger, mock_datetime):
 @patch("awswrangler.s3")
 def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
 
-    # The job runs on jan 2
-    fixed_date = datetime(2025, 1, 2)
-
-    # We get the last modified date from the S3 bucket as two days prior (for a buffer)
-    last_modified_begin = datetime(2024, 12, 31).replace(tzinfo=timezone.utc)
-    last_modified_end = datetime(2025, 1, 1).replace(tzinfo=timezone.utc)
-    mock_timestamp.now.return_value = fixed_date
+    fixed_date = datetime(1970, 1, 2)
+    fixed_date_yesterday = datetime(1970, 1, 1)
+    mock_timestamp.today.return_value = fixed_date
 
     # This data has timestamp of jan 1st
     mock_wr_s3.read_parquet.return_value = sample_data_df
@@ -245,7 +239,7 @@ def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
         drop_columns=["ispublished"],
         field_count_columns=["checkbox_count", "muffin_count"],
         email_columns=["deliveryemaildestination"],
-        partition_columns=["year", "month", "day"],
+        partition_columns=["year", "month"],
         partition_timestamp="timestamp",
     )
 
@@ -254,8 +248,7 @@ def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
         path=f"s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/test-path/",
         use_threads=True,
         dataset=True,
-        last_modified_begin=last_modified_begin,
-        last_modified_end=last_modified_end,
+        last_modified_begin=fixed_date_yesterday,
     )
 
     # Verify data is processed correctly
@@ -264,39 +257,39 @@ def test_get_new_data(mock_wr_s3, mock_timestamp, sample_data_df):
     assert "ispublished" not in result.columns
 
     # One row is dropped because its dated after the job run date
-    assert len(result) == len(sample_data_df) - 1
+    assert len(result) == len(sample_data_df)
 
     # Verify email columns are processed correctly
-    assert (result["deliveryemaildestination"].values == ["bar.com", "baz.com"]).all()
+    assert (
+        result["deliveryemaildestination"].values == ["bar.com", "baz.com", None]
+    ).all()
 
     # Verify field count columns are processed correctly
-    assert (result["checkbox_count"].values == [63, 0]).all()
-    assert (result["muffin_count"].values == [0, 0]).all()
+    assert (result["checkbox_count"].values == [63, 0, 0]).all()
+    assert (result["muffin_count"].values == [0, 0, 0]).all()
 
     # Test date columns TZ localization
     for date_column in ["ttl", "timestamp", "created_at"]:
         assert result[date_column].dt.tz is None
 
 
+@patch("pandas.Timestamp")
 @patch("awswrangler.s3")
-def test_get_new_data_historical(mock_wr_s3, sample_data_df):
+def test_get_new_data_historical(mock_wr_s3, mock_timestamp, sample_data_df):
 
-    first_date = "2025-01-01"
-    last_date = "2025-01-02"
-    last_modified_begin = datetime(2024, 12, 31).replace(tzinfo=timezone.utc)
-    last_modified_end = datetime(2025, 1, 2).replace(tzinfo=timezone.utc)
+    fixed_date = datetime(1970, 1, 2)
+    fixed_date_yesterday = datetime(1970, 1, 1)
+    mock_timestamp.today.return_value = fixed_date
 
     mock_wr_s3.read_parquet.return_value = sample_data_df
 
     result = get_new_data(
-        first_date=first_date,
-        last_date=last_date,
         path="test-path",
         date_columns=["ttl", "timestamp", "created_at"],
         drop_columns=["ispublished"],
         field_count_columns=["checkbox_count", "muffin_count"],
         email_columns=["deliveryemaildestination"],
-        partition_columns=["year", "month", "day"],
+        partition_columns=["year", "month"],
         partition_timestamp="timestamp",
     )
 
@@ -305,8 +298,7 @@ def test_get_new_data_historical(mock_wr_s3, sample_data_df):
         path=f"s3://{SOURCE_BUCKET}/{SOURCE_PREFIX}/test-path/",
         use_threads=True,
         dataset=True,
-        last_modified_begin=last_modified_begin,
-        last_modified_end=last_modified_end,
+        last_modified_begin=fixed_date_yesterday,
     )
 
     # Verify data is processed correctly


### PR DESCRIPTION
# Summary | Résumé

Rollback glue table partitioning

# Test instructions | Instructions pour tester la modification

1) Run Gc forms glue job with;
timeout=60,
writemode = overwrite 
yesterday = yesterday = pd.Timestamp.today(tz="UTC") - pd.Timedelta(days=5000)

2) Ensure the glue table is adequate
3) rollback the parameters