### PR TITLE
fix: only display Spark ETL job errors

### DIFF
--- a/terragrunt/aws/alarms/logs.tf
+++ b/terragrunt/aws/alarms/logs.tf
@@ -35,6 +35,7 @@ resource "aws_cloudwatch_query_definition" "glue_etl_spark_errors" {
   query_string = <<-QUERY
     fields @timestamp, @message, @logStream
     | filter @message like /ERROR/
+    | filter @message like /com.amazonaws.services.glue.log.GlueLogger/
     | sort @timestamp desc
     | limit 100
   QUERY


### PR DESCRIPTION
# Summary
Update the Log Insights query to only show errors from the ETL jobs without any of the Spark system setup/teardown logging included.