### PR TITLE
fix: CloudWatch anomaly metric pattern

### DIFF
--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -11,7 +11,7 @@ locals {
   glue_etl_spark_error_metric_name           = "glue-etl-spark-error"
   glue_etl_spark_metric_filter_error_pattern = "[(w1=\"*ERROR*com.amazonaws.services.glue.log.GlueLogger*\")]"
 
-  glue_etl_metric_filter_anomaly_pattern   = "Data-Anomaly"
+  glue_etl_metric_filter_anomaly_pattern   = "Anomaly"
   glue_etl_pythonshell_anomaly_metric_name = "glue-etl-pythonshell-anomaly"
   glue_etl_spark_anomaly_metric_name       = "glue-etl-spark-anomaly"
 }


### PR DESCRIPTION
# Summary
The dash in the metric filter pattern is causing problems with matching on the expected log items.

# Related
- https://github.com/cds-snc/data-lake/pull/304