### PR TITLE
fix: switch to logger.warn to support Glue Python version

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data.py
@@ -281,7 +281,7 @@ def detect_anomalies(
 
     is_anomaly = abs(z_score) > standard_deviation_threshold
     if is_anomaly:
-        logger.warning(
+        logger.warn(
             f"Data-Anomaly for {dataset}: Latest value {row_count}, mean: {mean:.2f}, "
             f"stdev: {standard_deviation:.2f}, z_score: {z_score:.2f}"
         )

--- a/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_forms/process_data_test.py
@@ -664,8 +664,8 @@ def test_detect_anomalies_outlier(mock_logger):
     result = detect_anomalies("foo", row_count, historical_data, 2.0)
 
     assert result == True
-    mock_logger.warning.assert_called_once()
-    assert "Data-Anomaly for foo: Latest value" in mock_logger.warning.call_args[0][0]
+    mock_logger.warn.assert_called_once()
+    assert "Data-Anomaly for foo: Latest value" in mock_logger.warn.call_args[0][0]
 
 
 def test_detect_anomalies_zero_standard_deviation():

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -392,7 +392,7 @@ def detect_anomalies(
 
     is_anomaly = abs(z_score) > standard_deviation_threshold
     if is_anomaly:
-        logger.warning(
+        logger.warn(
             f"Data-Anomaly for {dataset}: Latest value {row_count}, Mean: {mean:.2f}, "
             f"Standard dev.: {standard_deviation:.2f}, Z-score: {z_score:.2f}, "
             f"Historical data: {historical_data}"

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
@@ -669,8 +669,8 @@ def test_detect_anomalies_outlier(mock_logger):
     result = detect_anomalies("foo", row_count, historical_data, 2.0)
 
     assert result == True
-    mock_logger.warning.assert_called_once()
-    assert "Data-Anomaly for foo: Latest value" in mock_logger.warning.call_args[0][0]
+    mock_logger.warn.assert_called_once()
+    assert "Data-Anomaly for foo: Latest value" in mock_logger.warn.call_args[0][0]
 
 
 def test_detect_anomalies_zero_standard_deviation():

--- a/terragrunt/aws/glue/etl/platform/support/freshdesk/process_tickets.py
+++ b/terragrunt/aws/glue/etl/platform/support/freshdesk/process_tickets.py
@@ -163,7 +163,7 @@ def get_days_tickets(day: datetime) -> pd.DataFrame:
             new_tickets[date_column] = new_tickets[date_column].dt.tz_localize(None)
 
     except wr.exceptions.NoFilesFound:
-        logger.warning("No new tickets found.")
+        logger.warn("No new tickets found.")
     return new_tickets
 
 
@@ -186,7 +186,7 @@ def get_existing_tickets(start_date: str) -> pd.DataFrame:
             None
         )  # Treat all as UTC
     except wr.exceptions.NoFilesFound:
-        logger.warning("No existing data found. Starting fresh.")
+        logger.warn("No existing data found. Starting fresh.")
 
     return existing_tickets
 
@@ -299,7 +299,7 @@ def detect_anomalies(
 
     is_anomaly = abs(z_score) > standard_deviation_threshold
     if is_anomaly:
-        logger.warning(
+        logger.warn(
             f"Data-Anomaly for Freshdesk: Latest value {row_count}, mean: {mean:.2f}, "
             f"stdev: {standard_deviation:.2f}, z_score: {z_score:.2f}"
         )

--- a/terragrunt/aws/glue/etl/platform/support/freshdesk/process_tickets_test.py
+++ b/terragrunt/aws/glue/etl/platform/support/freshdesk/process_tickets_test.py
@@ -420,10 +420,9 @@ def test_detect_anomalies_outlier(mock_logger):
     result = detect_anomalies(row_count, historical_data, 2.0)
 
     assert result == True
-    mock_logger.warning.assert_called_once()
+    mock_logger.warn.assert_called_once()
     assert (
-        "Data-Anomaly for Freshdesk: Latest value"
-        in mock_logger.warning.call_args[0][0]
+        "Data-Anomaly for Freshdesk: Latest value" in mock_logger.warn.call_args[0][0]
     )
 
 


### PR DESCRIPTION
# Summary
The Python version running in the Glue jobs only supports `logger.warn`.