### PR TITLE
feat: allow Superset prod IAM role access to Notify data

### DIFF
--- a/terragrunt/env/production/env_vars.hcl
+++ b/terragrunt/env/production/env_vars.hcl
@@ -6,6 +6,7 @@ inputs = {
   superset_iam_role_arns = [
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_gc_forms_production",
+    "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_gc_notify_production",
     "arn:aws:iam::066023111852:role/SupersetAthenaRead-platform_support_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-operations_aws_production",
     "arn:aws:iam::257394494478:role/SupersetAthenaRead-platform_gc_forms_production",


### PR DESCRIPTION
# Summary
Update the Superset IAM roles to include the new Notify prod role.  This is the second step of onboarding the Notify prod dataset to Superset prod.

# Related
- https://github.com/cds-snc/cds-superset/pull/445