### PR TITLE
feat: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Users that are allowed to approve PRs
+* @cds-snc/platform-core-services


### PR DESCRIPTION
# Summary
Add a CODEOWNERS file so that only members of the Platform Core Services team can approve PRs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/757