### PR TITLE
feat: enable stepfunctions orchestrator

### DIFF
--- a/terragrunt/aws/glue/curated.tf
+++ b/terragrunt/aws/glue/curated.tf
@@ -16,11 +16,11 @@ resource "aws_glue_job" "platform_gc_notify_curated" {
   name = "Platform / GC Notify / Curated / Notification Enriched"
 
   glue_version           = "5.0"
-  timeout                = 15 # minutes 
+  timeout                = 60 # minutes - increased for large datasets
   role_arn               = aws_iam_role.glue_etl.arn
   security_configuration = aws_glue_security_configuration.encryption_at_rest.name
-  worker_type            = "G.1X"
-  number_of_workers      = 2
+  worker_type            = "G.2X"
+  number_of_workers      = 4 # Increased workers for better parallelization
 
   command {
     script_location = "s3://${var.glue_bucket_name}/${aws_s3_object.platform_gc_notify_curated_job.key}"

--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -60,6 +60,21 @@ job = Job(glueContext)
 job.init(JOB_NAME, args)
 logger = glueContext.get_logger()
 
+# Configure Spark to handle schema evolution and empty partitions
+if spark is not None:
+    # Enable schema merging for Parquet files to handle schema evolution
+    spark.conf.set("spark.sql.parquet.mergeSchema", "true")
+    # Handle empty partitions and schema evolution more gracefully
+    spark.conf.set("spark.sql.parquet.enableVectorizedReader", "false")
+    # Ignore missing files and corrupt files
+    spark.conf.set("spark.sql.files.ignoreMissingFiles", "true")
+    spark.conf.set("spark.sql.files.ignoreCorruptFiles", "true")
+    # Enable adaptive type coercion
+    spark.conf.set("spark.sql.adaptive.enabled", "true")
+    spark.conf.set("spark.sql.adaptive.coalescePartitions.enabled", "true")
+    # Handle partition discovery issues
+    spark.conf.set("spark.sql.sources.partitionColumnTypeInference.enabled", "false")
+
 
 def execute_enrichment_query(
     start_month_str: str, end_month_str: str

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -68,7 +68,7 @@ resource "aws_glue_trigger" "platform_gc_forms_job" {
   name     = "Platform / GC Forms"
   schedule = "cron(00 2 * * ? *)" # 2am UTC every day
   type     = "SCHEDULED"
-  enabled  = local.is_production
+  enabled  = false # Change for local.is_production to enable
 
   actions {
     job_name = aws_glue_job.platform_gc_forms_job.name
@@ -171,7 +171,7 @@ resource "aws_glue_trigger" "platform_gc_notify_job" {
   name     = "Platform / GC Notify"
   schedule = "cron(0 7 * * ? *)" # Daily at 7am UTC
   type     = "SCHEDULED"
-  enabled  = local.is_production
+  enabled  = false # Change for local.is_production to enable
 
   actions {
     job_name = aws_glue_job.platform_gc_notify_job.name
@@ -246,7 +246,7 @@ resource "aws_glue_trigger" "platform_support_freshdesk" {
   name     = "Platform / Support / Freshdesk"
   schedule = "cron(00 7 * * ? *)" # 7am UTC every day
   type     = "SCHEDULED"
-  enabled  = local.is_production
+  enabled  = false # Change for local.is_production to enable
 
   actions {
     job_name = aws_glue_job.platform_support_freshdesk.name

--- a/terragrunt/aws/stepfunctions/stepfunctions.tf
+++ b/terragrunt/aws/stepfunctions/stepfunctions.tf
@@ -16,3 +16,20 @@ resource "aws_sfn_state_machine" "data_orchestrator" {
   role_arn   = aws_iam_role.sfn_role.arn
   definition = data.template_file.data_orchestrator_state_machine.rendered
 }
+
+# CloudWatch EventBridge rule to trigger the state machine at 2AM daily
+# Enabled in production, disabled in staging for testing
+resource "aws_cloudwatch_event_rule" "data_orchestrator_schedule" {
+  name                = "data-orchestrator-daily-schedule"
+  description         = "Trigger DataLakeOrchestrator state machine daily at 2AM UTC"
+  schedule_expression = "cron(0 7 * * ? *)" # Daily at 7am UTC
+  state               = var.env == "production" ? "ENABLED" : "DISABLED"
+}
+
+# CloudWatch EventBridge target to execute the state machine
+resource "aws_cloudwatch_event_target" "data_orchestrator_target" {
+  rule      = aws_cloudwatch_event_rule.data_orchestrator_schedule.name
+  target_id = "DataOrchestratorTarget"
+  arn       = aws_sfn_state_machine.data_orchestrator.arn
+  role_arn  = aws_iam_role.eventbridge_sfn_role.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Enabling statefunction orchestrator

# Test instructions | Instructions pour tester la modification

> In staging, manually overwrite the event bridge rule cron schedule to make sure the SFN can be triggered by event bridge
> After confirming that the SFN is launched and that all the glue jobs can be started from the SFN, disable the event bridge rule again
> Make sure the glue job's cron schedules are disabled