### PR TITLE
feat: migrating curated database to transformed database

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,12 +14,9 @@
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "1.12.2",
       "terragrunt": "0.68.6"
-    },
-    "ghcr.io/devcontainers/features/java:1": {
-      "version": "17",
-      "jdkDistro": "temurin"
     }
   },
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y openjdk-17-jdk && export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/terragrunt/aws/glue/curated.tf
+++ b/terragrunt/aws/glue/curated.tf
@@ -37,11 +37,10 @@ resource "aws_glue_job" "platform_gc_notify_curated" {
     "--enable-metrics"                   = "true"
     "--enable-observability-metrics"     = "true"
     "--job-language"                     = "python"
-    "--curated_bucket"                   = var.curated_bucket_name
-    "--curated_prefix"                   = "platform/gc-notify"
+    "--transformed_bucket"               = var.transformed_bucket_name
+    "--transformed_prefix"               = "platform/gc-notify"
     "--enable-glue-datacatalog"          = "true"
     "--database_name_transformed"        = aws_glue_catalog_database.platform_gc_notify_production.name
-    "--database_name_curated"            = aws_glue_catalog_database.platform_gc_notify_production_curated.name
     "--target_env"                       = var.env
     "--start_month"                      = " " # Default empty - will use current and previous month
     "--end_month"                        = " " # Default empty - will use current and previous month

--- a/terragrunt/aws/glue/iam.tf
+++ b/terragrunt/aws/glue/iam.tf
@@ -130,7 +130,6 @@ data "aws_iam_policy_document" "s3_read_data_lake" {
       "s3:GetObject",
     ]
     resources = [
-      "${var.curated_bucket_arn}/*",
       "${var.glue_bucket_arn}/*",
       "${var.raw_bucket_arn}/*",
       "${var.transformed_bucket_arn}/*"
@@ -203,7 +202,6 @@ data "aws_iam_policy_document" "s3_write_data_lake" {
       "s3:DeleteObject"
     ]
     resources = [
-      "${var.curated_bucket_arn}/*",
       "${var.transformed_bucket_arn}/*",
       "${var.raw_bucket_arn}/*"
     ]

--- a/terragrunt/aws/glue/variables.tf
+++ b/terragrunt/aws/glue/variables.tf
@@ -8,16 +8,6 @@ variable "athena_bucket_name" {
   type        = string
 }
 
-variable "curated_bucket_arn" {
-  description = "The ARN of the Curated bucket"
-  type        = string
-}
-
-variable "curated_bucket_name" {
-  description = "The name of the Curated bucket"
-  type        = string
-}
-
 variable "glue_bucket_arn" {
   description = "The ARN of the Glue bucket"
   type        = string

--- a/terragrunt/env/production/glue/terragrunt.hcl
+++ b/terragrunt/env/production/glue/terragrunt.hcl
@@ -13,8 +13,6 @@ dependency "buckets" {
   mock_outputs = {
     athena_bucket_arn      = "arn:aws:s3:::mock-athena-bucket"
     athena_bucket_name     = "mock-athena-bucket"
-    curated_bucket_arn      = "arn:aws:s3:::mock-curated-bucket"
-    curated_bucket_name     = "mock-curated-bucket"
     glue_bucket_arn         = "arn:aws:s3:::mock-glue-bucket"
     glue_bucket_name        = "mock-glue-bucket"
     raw_bucket_arn          = "arn:aws:s3:::mock-raw-bucket"
@@ -27,8 +25,6 @@ dependency "buckets" {
 inputs = {
   athena_bucket_arn       = dependency.buckets.outputs.athena_bucket_arn
   athena_bucket_name      = dependency.buckets.outputs.athena_bucket_name
-  curated_bucket_arn      = dependency.buckets.outputs.curated_bucket_arn
-  curated_bucket_name     = dependency.buckets.outputs.curated_bucket_name
   glue_bucket_arn         = dependency.buckets.outputs.glue_bucket_arn
   glue_bucket_name        = dependency.buckets.outputs.glue_bucket_name
   raw_bucket_arn          = dependency.buckets.outputs.raw_bucket_arn

--- a/terragrunt/env/staging/glue/terragrunt.hcl
+++ b/terragrunt/env/staging/glue/terragrunt.hcl
@@ -13,8 +13,6 @@ dependency "buckets" {
   mock_outputs = {
     athena_bucket_arn      = "arn:aws:s3:::mock-athena-bucket"
     athena_bucket_name     = "mock-athena-bucket"
-    curated_bucket_arn      = "arn:aws:s3:::mock-curated-bucket"
-    curated_bucket_name     = "mock-curated-bucket"
     glue_bucket_arn         = "arn:aws:s3:::mock-glue-bucket"
     glue_bucket_name        = "mock-glue-bucket"
     raw_bucket_arn          = "arn:aws:s3:::mock-raw-bucket"
@@ -27,8 +25,6 @@ dependency "buckets" {
 inputs = {
   athena_bucket_arn       = dependency.buckets.outputs.athena_bucket_arn
   athena_bucket_name      = dependency.buckets.outputs.athena_bucket_name
-  curated_bucket_arn      = dependency.buckets.outputs.curated_bucket_arn
-  curated_bucket_name     = dependency.buckets.outputs.curated_bucket_name
   glue_bucket_arn         = dependency.buckets.outputs.glue_bucket_arn
   glue_bucket_name        = dependency.buckets.outputs.glue_bucket_name
   raw_bucket_arn          = dependency.buckets.outputs.raw_bucket_arn


### PR DESCRIPTION
# Summary | Résumé

Moving the curated table to the transformed database to make it easily accessible in superset, and joinable with other transformed tables


# Test instructions | Instructions pour tester la modification

1) Run the pipeline in staging, with start date 2000-01
2) Deploy to prod and also run with the early start date
3) Revert the start date back to default value of " "