### PR TITLE
fix: Notify ETL job should overwrite data instead of appending

### DIFF
--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -69,6 +69,7 @@ spark = glueContext.spark_session
 # Configure Spark to handle timestamp parsing issues with Spark 3.0+
 if spark is not None:
     spark.conf.set("spark.sql.legacy.timeParserPolicy", "LEGACY")
+    spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
 
 logger = glueContext.get_logger()
 
@@ -515,33 +516,31 @@ def process_data():
                     f"Great Expectations validation failed for {table_name}. Aborting ETL process."
                 )
 
-            # Save the transformed data back to S3 using Glue
+            # Save the transformed data back to S3 using Spark
             logger.info(f"Saving new {table_name} DataFrame to S3...")
             table = f"{TABLE_NAME_PREFIX}_{table_name}"
 
             # Convert Spark DataFrame to Glue DynamicFrame for native integration
             dynamic_frame = DynamicFrame.fromDF(data, glueContext, table)
 
-            # Write using Glue's native capabilities with catalog updates enabled
+            # Convert DynamicFrame to Spark DataFrame
+            spark_df = dynamic_frame.toDF()
+
+            # Explicitly set dynamic partition overwrite mode before writing
+            spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
+
+
+            # Write the DataFrame to S3 using Spark's write method with dynamic partition overwrite
             s3_output_path = f"{TRANSFORMED_PATH}/{table_name}/"
 
-            glueContext.write_dynamic_frame.from_options(
-                frame=dynamic_frame,
-                connection_type="s3",
-                connection_options={
-                    "path": s3_output_path,
-                    "partitionKeys": partition_cols if partition_cols else [],
-                    "enableUpdateCatalog": True,
-                    "updateBehavior": "UPDATE_IN_DATABASE",
-                    "catalogDatabase": DATABASE_NAME_TRANSFORMED,
-                    "catalogTableName": table,
-                },
-                format="glueparquet",
-                format_options={"compression": "snappy"},
-                transformation_ctx=f"write_{table_name}",
-            )
+            if partition_cols:
+                spark_df.write.mode("overwrite").partitionBy(partition_cols).parquet(
+                    s3_output_path
+                )
+            else:
+                spark_df.write.mode("overwrite").parquet(s3_output_path)
 
-            logger.info(f"Successfully wrote {row_count} records to {s3_output_path}")
+            logger.info(f"Successfully wrote {row_count} records to {s3_output_path} using Spark DataFrame write.")
             logger.info(f"Data written with partitions: {partition_cols}")
             logger.info(f"Catalog table: {DATABASE_NAME_TRANSFORMED}.{table}")
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -529,7 +529,6 @@ def process_data():
             # Explicitly set dynamic partition overwrite mode before writing
             spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
 
-
             # Write the DataFrame to S3 using Spark's write method with dynamic partition overwrite
             s3_output_path = f"{TRANSFORMED_PATH}/{table_name}/"
 
@@ -540,7 +539,9 @@ def process_data():
             else:
                 spark_df.write.mode("overwrite").parquet(s3_output_path)
 
-            logger.info(f"Successfully wrote {row_count} records to {s3_output_path} using Spark DataFrame write.")
+            logger.info(
+                f"Successfully wrote {row_count} records to {s3_output_path} using Spark DataFrame write."
+            )
             logger.info(f"Data written with partitions: {partition_cols}")
             logger.info(f"Catalog table: {DATABASE_NAME_TRANSFORMED}.{table}")
 

--- a/terragrunt/aws/stepfunctions/state_machines/data_lake_orchestrator.json
+++ b/terragrunt/aws/stepfunctions/state_machines/data_lake_orchestrator.json
@@ -4,7 +4,7 @@
   "States": {
     "ParallelTransformedJobs": {
       "Type": "Parallel",
-      "Next": "AllJobsComplete",
+      "Next": "ParallelCuratedJobs",
       "Branches": [
         {
           "StartAt": "StartGCFormsJob",
@@ -98,6 +98,36 @@
             "SalesforceJobFailed": {
               "Type": "Pass",
               "Result": "Salesforce Glue job failed",
+              "End": true
+            }
+          }
+        }
+      ]
+    },
+    "ParallelCuratedJobs": {
+      "Type": "Parallel",
+      "Next": "AllJobsComplete",
+      "Branches": [
+        {
+          "StartAt": "StartGCNotifyCuratedJob",
+          "States": {
+            "StartGCNotifyCuratedJob": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::glue:startJobRun.sync",
+              "Parameters": {
+                "JobName": "${platform_gc_notify_curated_job_name}"
+              },
+              "Catch": [
+                {
+                  "ErrorEquals": ["States.ALL"],
+                  "Next": "GCNotifyCuratedJobFailed"
+                }
+              ],
+              "End": true
+            },
+            "GCNotifyCuratedJobFailed": {
+              "Type": "Pass",
+              "Result": "GC Notify Curated Glue job failed",
               "End": true
             }
           }

--- a/terragrunt/aws/stepfunctions/state_machines/data_lake_orchestrator.json
+++ b/terragrunt/aws/stepfunctions/state_machines/data_lake_orchestrator.json
@@ -4,7 +4,7 @@
   "States": {
     "ParallelTransformedJobs": {
       "Type": "Parallel",
-      "Next": "ParallelCuratedJobs",
+      "Next": "AllJobsComplete",
       "Branches": [
         {
           "StartAt": "StartGCFormsJob",
@@ -98,36 +98,6 @@
             "SalesforceJobFailed": {
               "Type": "Pass",
               "Result": "Salesforce Glue job failed",
-              "End": true
-            }
-          }
-        }
-      ]
-    },
-    "ParallelCuratedJobs": {
-      "Type": "Parallel",
-      "Next": "AllJobsComplete",
-      "Branches": [
-        {
-          "StartAt": "StartGCNotifyCuratedJob",
-          "States": {
-            "StartGCNotifyCuratedJob": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::glue:startJobRun.sync",
-              "Parameters": {
-                "JobName": "${platform_gc_notify_curated_job_name}"
-              },
-              "Catch": [
-                {
-                  "ErrorEquals": ["States.ALL"],
-                  "Next": "GCNotifyCuratedJobFailed"
-                }
-              ],
-              "End": true
-            },
-            "GCNotifyCuratedJobFailed": {
-              "Type": "Pass",
-              "Result": "GC Notify Curated Glue job failed",
               "End": true
             }
           }


### PR DESCRIPTION
# Summary | Résumé

A bug was introduced when converting the pandas notify ETL to a spark job where the data was appended instead of overwriting partitions.

Fixing this bug also makes the gold table glue job much quicker (3 minutes) - therefore I will reactivate it.

# Test instructions | Instructions pour tester la modification

Notify ETL

1. Run twice in staging, make sure the data count is stable
2. Run in production, with a hard-coded value for the lookback period = 30
3. Rollback the lookback period to previous value

Gold Table

1. Run in staging with start date = 2020-01
2. Reset start_date =" "
3. Run in prod with start date = 2020-01
4. Reset start_date =" "