### PR TITLE
Fix notifypipelines updates glue metadata

### DIFF
--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -204,7 +204,7 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
         # Remove 'platform_gc_notify_' prefix from table name for S3 path
         s3_subdir = table_name
         if s3_subdir.startswith("platform_gc_notify_"):
-            s3_subdir = s3_subdir[len("platform_gc_notify_") :]
+            s3_subdir = s3_subdir[len("platform_gc_notify_"):]
         s3_path = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}/{s3_subdir}/"
 
         logger.info(f"Writing {row_count} rows to {s3_path}")

--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -201,7 +201,11 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
     """Write the enriched dataset to the curated bucket with partitioning and overwrite."""
     try:
         row_count = df.count()
-        s3_path = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}/{table_name}/"
+        # Remove 'platform_gc_notify_' prefix from table name for S3 path
+        s3_subdir = table_name
+        if s3_subdir.startswith("platform_gc_notify_"):
+            s3_subdir = s3_subdir[len("platform_gc_notify_"):]
+        s3_path = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}/{s3_subdir}/"
 
         logger.info(f"Writing {row_count} rows to {s3_path}")
         logger.info("Partitioning by: year, month")

--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -60,18 +60,7 @@ logger = glueContext.get_logger()
 
 # Configure Spark to handle schema evolution and empty partitions
 if spark is not None:
-    # Enable schema merging for Parquet files to handle schema evolution
-    # spark.conf.set("spark.sql.parquet.mergeSchema", "true")
-    # Handle empty partitions and schema evolution more gracefully
-    # spark.conf.set("spark.sql.parquet.enableVectorizedReader", "false")
-    # Ignore missing files and corrupt files
-    spark.conf.set("spark.sql.files.ignoreMissingFiles", "true")
-    spark.conf.set("spark.sql.files.ignoreCorruptFiles", "true")
-    # Enable adaptive type coercion
-    spark.conf.set("spark.sql.adaptive.enabled", "true")
-    spark.conf.set("spark.sql.adaptive.coalescePartitions.enabled", "true")
-    # Handle partition discovery issues
-    spark.conf.set("spark.sql.sources.partitionColumnTypeInference.enabled", "false")
+    spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
 
 
 def execute_enrichment_query(
@@ -216,9 +205,6 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
 
         logger.info(f"Writing {row_count} rows to {s3_path}")
         logger.info("Partitioning by: year, month")
-
-        # First, write the parquet files with dynamic partition overwrite
-        spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
 
         df.write.mode("overwrite").partitionBy("year", "month").parquet(s3_path)
 

--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -214,8 +214,12 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
         )
 
         # Create temp view from the original DataFrame (no extra read needed)
-        df.createOrReplaceTempView("temp_table_for_registration")
+        df.limit(0).createOrReplaceTempView("temp_table_for_registration")
 
+        # Register table in Glue Data Catalog using Spark SQL
+        # Drop table if exists to avoid schema drift
+        spark.sql(f"DROP TABLE IF EXISTS {DATABASE_NAME_TRANSFORMED}.{table_name}")
+        
         # Create the table in Glue Data Catalog using the original DataFrame's schema
         spark.sql(
             f"""

--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -202,9 +202,7 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
     try:
         row_count = df.count()
         # Remove 'platform_gc_notify_' prefix from table name for S3 path
-        s3_subdir = table_name
-        if s3_subdir.startswith("platform_gc_notify_"):
-            s3_subdir = s3_subdir[len("platform_gc_notify_"):]
+        s3_subdir = table_name.removeprefix("platform_gc_notify_")
         s3_path = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}/{s3_subdir}/"
 
         logger.info(f"Writing {row_count} rows to {s3_path}")

--- a/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
+++ b/terragrunt/aws/glue/curated/platform/gc_notify/notification_enriched.py
@@ -204,7 +204,7 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
         # Remove 'platform_gc_notify_' prefix from table name for S3 path
         s3_subdir = table_name
         if s3_subdir.startswith("platform_gc_notify_"):
-            s3_subdir = s3_subdir[len("platform_gc_notify_"):]
+            s3_subdir = s3_subdir[len("platform_gc_notify_") :]
         s3_path = f"s3://{TRANSFORMED_BUCKET}/{TRANSFORMED_PREFIX}/{s3_subdir}/"
 
         logger.info(f"Writing {row_count} rows to {s3_path}")
@@ -223,7 +223,6 @@ def write_to_curated(df: SparkDataFrame, table_name: str):
         # Register table in Glue Data Catalog using Spark SQL
         # Drop table if exists to avoid schema drift
         spark.sql(f"DROP TABLE IF EXISTS {DATABASE_NAME_TRANSFORMED}.{table_name}")
-        
         # Create the table in Glue Data Catalog using the original DataFrame's schema
         spark.sql(
             f"""


### PR DESCRIPTION
# Summary | Résumé

This PR fixes two issues:

### **1) Glue Schema Out of Sync**

The spark ETL for Notify uses spark types that are slightly different from the previous pandas types.
This has caused newer parquet files to have a format mis-match on some column when compared with the pre-migration parquet. The Glue table metadata was still expecting the old format.

This mismatch caused a bug downstream where data with unexpected format was ignored in SQL queries

**FIX:** We can de-register and re-register the glue tables. This is light weight as its only a metadata operation.

### **2) Old partitions not deleted**

The ETL script reads the raw tables:

- The last 2 months of data for notification_history (incremental_load=True) 
- All data in from raw bucket for other tables (incremental_load=False)

The write steps has an overwrite_partition parameter, meaning that:

- For notification_history (incremental_load = True) only the most recent months gets re-written
- For full loads, the whole content of the table gets rewritten to transformed

However, I believe this has never worked as intended for the notification table:

1) The table only contains data for the past few days/weeks. Even if we read all the data from the raw table, we only get one or two distinct months
2) Because there is no data for the older months - their associated partition do not exist in the data that we are trying to output. The old `mode ="overwrite_partition"` (pandas), or the newer `spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")` have the same behaviour: they will overwrite partitions if and only they are present in the dataset

**FIX:** The fix is simply to explicitly delete the buckets of the tables that need full reprocessing

# Test instructions | Instructions pour tester la modification

1) Run the notify pipeline since the start. This can be achieved by hard-coding incremental_load = False. We can try with 5 G.4x workers 
2) Run the gold table ETL. For the initial load, set start_date=2010-01 (Use default workers)
3) If everything goes well, reset the parameters from both ETLs, and do the same procedure in prod