### PR TITLE
fix: changing the glue name so its available in superset

### DIFF
--- a/terragrunt/aws/glue/databases.tf
+++ b/terragrunt/aws/glue/databases.tf
@@ -54,6 +54,6 @@ resource "aws_glue_catalog_database" "platform_gc_notify_production_curated" {
 }
 
 resource "aws_glue_catalog_database" "platform_gc_design_system" {
-  name        = "platform_gc_design_system"
+  name        = "platform_gc_design_system_${var.env}"
   description = "TRANSFORMED: data source path: /platform/gc-design-system/*"
 }


### PR DESCRIPTION
# Summary | Résumé

Minor change to add the environment suffix to the glue tables. Superset only sees tables that end with _production or _staging


# Test instructions | Instructions pour tester la modification

Run the new crawlers
Delete old table

