### PR TITLE
fix: trigger release - give superset proper access to glue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* added historical data load ([#382](https://github.com/cds-snc/data-lake/issues/382)) ([2f793e4](https://github.com/cds-snc/data-lake/commit/2f793e4dd4b118983c482c4d1f396eca62e57f5d))
+* added historical data load  ([#382](https://github.com/cds-snc/data-lake/issues/382)) ([2f793e4](https://github.com/cds-snc/data-lake/commit/2f793e4dd4b118983c482c4d1f396eca62e57f5d))
 
 
 ### Bug Fixes


### PR DESCRIPTION
# Summary | Résumé

When rebasing - I ended up using the wrong commit message. Creating a "dummy" PR to trigger the release bot.