### PR TITLE
feat: add OIDC role to manage GitHub data exports

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -38,12 +38,12 @@ jobs:
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terragrunt apply oidc
-        working-directory: terragrunt/env/production/oidc
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
-
       - name: Terragrunt apply buckets
         working-directory: terragrunt/env/production/buckets
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply oidc
+        working-directory: terragrunt/env/production/oidc
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply glue

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -44,12 +44,12 @@ jobs:
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terragrunt apply oidc
-        working-directory: terragrunt/env/staging/oidc
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve
-
       - name: Terragrunt apply buckets
         working-directory: terragrunt/env/staging/buckets
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply oidc
+        working-directory: terragrunt/env/staging/oidc
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Terragrunt apply glue

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -41,21 +41,21 @@ jobs:
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terragrunt plan oidc
-        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
-        with:
-          directory: "terragrunt/env/production/oidc"
-          comment-delete: "true"
-          comment-title: "Production: oidc 🔑"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
       - name: Terragrunt plan buckets
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:
           directory: "terragrunt/env/production/buckets"
           comment-delete: "true"
           comment-title: "Production: buckets 🪣"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan oidc
+        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
+        with:
+          directory: "terragrunt/env/production/oidc"
+          comment-delete: "true"
+          comment-title: "Production: oidc 🔑"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -45,21 +45,21 @@ jobs:
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terragrunt plan oidc
-        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
-        with:
-          directory: "terragrunt/env/staging/oidc"
-          comment-delete: "true"
-          comment-title: "Staging: oidc 🔑"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
       - name: Terragrunt plan buckets
         uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
         with:
           directory: "terragrunt/env/staging/buckets"
           comment-delete: "true"
           comment-title: "Staging: buckets 🪣"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan oidc
+        uses: cds-snc/terraform-plan@e710cb1446e5dfe69a0182603fb06b5282d7eb07 # v3.4.3
+        with:
+          directory: "terragrunt/env/staging/oidc"
+          comment-delete: "true"
+          comment-title: "Staging: oidc 🔑"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 

--- a/terragrunt/aws/oidc/oidc.tf
+++ b/terragrunt/aws/oidc/oidc.tf
@@ -1,5 +1,6 @@
 locals {
-  data_lake_release = "data-lake-release"
+  data_lake_release            = "data-lake-release"
+  data_lake_github_data_export = "data-lake-github-data-export"
 }
 
 #
@@ -17,6 +18,11 @@ module "github_workflow_roles" {
       name      = local.data_lake_release
       repo_name = "data-lake"
       claim     = "ref:refs/tags/v*" # Version tags prefixed with v
+    },
+    {
+      name      = local.data_lake_github_data_export
+      repo_name = "*"                  # Allow any CDS repo to use this role
+      claim     = "ref:refs/head/test" # Update to `main` once testing finished
     }
   ]
 }
@@ -24,6 +30,44 @@ module "github_workflow_roles" {
 #
 # Attach polices to the OIDC roles to grant them permissions.  These
 # attachments are scoped to only the environments that require the role.
+#
+
+#
+# Allow GitHub workflows in CDS repos to export data to the Raw S3 bucket
+#
+resource "aws_iam_role_policy_attachment" "data_lake_github_data_export" {
+  count = var.env == "production" ? 1 : 0
+
+  role       = local.data_lake_github_data_export
+  policy_arn = resource.aws_iam_policy.data_lake_github_data_export[0].arn
+  depends_on = [
+    module.github_workflow_roles[0]
+  ]
+}
+
+resource "aws_iam_policy" "data_lake_github_data_export" {
+  count = var.env == "production" ? 1 : 0
+
+  name   = local.data_lake_github_data_export
+  path   = "/service-role/"
+  policy = data.aws_iam_policy_document.s3_read_write_raw_github.json
+}
+
+data "aws_iam_policy_document" "s3_read_write_raw_github" {
+  statement {
+    sid = "ReadWriteRawGitHubS3Bucket"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = [
+      "${var.raw_bucket_arn}/operations/github/*"
+    ]
+  }
+}
+
+#
+# Runs after a new GitHub release is created to update Prod infrastructure
 #
 resource "aws_iam_role_policy_attachment" "data_lake_release" {
   count = var.env == "production" ? 1 : 0

--- a/terragrunt/aws/oidc/variables.tf
+++ b/terragrunt/aws/oidc/variables.tf
@@ -1,0 +1,4 @@
+variable "raw_bucket_arn" {
+  description = "The ARN of the Raw bucket"
+  type        = string
+}

--- a/terragrunt/env/production/oidc/terragrunt.hcl
+++ b/terragrunt/env/production/oidc/terragrunt.hcl
@@ -2,6 +2,23 @@ include {
   path = find_in_parent_folders("root.hcl")
 }
 
+dependencies {
+  paths = ["../buckets"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    raw_bucket_arn = "arn:aws:s3:::mock-raw-bucket"
+  }
+}
+
+inputs = {
+  raw_bucket_arn = dependency.buckets.outputs.raw_bucket_arn
+}
+
 terraform {
   source = "../../../aws//oidc"
 }

--- a/terragrunt/env/staging/oidc/terragrunt.hcl
+++ b/terragrunt/env/staging/oidc/terragrunt.hcl
@@ -2,6 +2,23 @@ include {
   path = find_in_parent_folders("root.hcl")
 }
 
+dependencies {
+  paths = ["../buckets"]
+}
+
+dependency "buckets" {
+  config_path                             = "../buckets"
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    raw_bucket_arn = "arn:aws:s3:::mock-raw-bucket"
+  }
+}
+
+inputs = {
+  raw_bucket_arn = dependency.buckets.outputs.raw_bucket_arn
+}
+
 terraform {
   source = "../../../aws//oidc"
 }


### PR DESCRIPTION
# Summary
Create a new OIDC role that can be used by any `cds-snc` repo to save objects to the Raw bucket's `/operations/github/` prefix.

# Related
- https://github.com/cds-snc/platform-core-services/issues/708