### PR TITLE
feat: allow GitHub export role to write to Raw bucket

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -79,4 +79,21 @@ data "aws_iam_policy_document" "raw_bucket" {
       "${module.raw_bucket.s3_bucket_arn}/*"
     ]
   }
+
+  statement {
+    sid    = "GitHubExportToBucket"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::739275439843:role/data-lake-github-data-export",
+      ]
+    }
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${module.raw_bucket.s3_bucket_arn}/operations/github/*"
+    ]
+  }
 }

--- a/terragrunt/aws/oidc/oidc.tf
+++ b/terragrunt/aws/oidc/oidc.tf
@@ -57,7 +57,6 @@ data "aws_iam_policy_document" "s3_read_write_raw_github" {
   statement {
     sid = "ReadWriteRawGitHubS3Bucket"
     actions = [
-      "s3:GetObject",
       "s3:PutObject",
     ]
     resources = [


### PR DESCRIPTION
# Summary
Update the Raw bucket policy to allow the new OIDC IAM role to write data.
