### PR TITLE
chore: enable Renovate OSV and GitHub vulnerability alert PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "vulnerabilityFixStrategy": "lowest"
+  },
   "extends": [
     "local>cds-snc/renovate-config"
   ]


### PR DESCRIPTION
# Summary
This configuration change will use Renovate's Open Source Vulnerability database to create Security PRs when a fix version is available.

Additionally it will create PRs if there is a GitHub vulnerability alert for a dependency.

# Related
- https://github.com/cds-snc/platform-core-services/issues/895