### PR TITLE
feat: allow Notify read-only access to their Raw data exports

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -107,9 +107,9 @@ data "aws_iam_policy_document" "raw_bucket" {
       ]
     }
     actions = [
-        "s3:GetObject",
-        "s3:ListBucket",
-        "s3:GetBucketLocation"
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
     ]
     resources = [
       module.raw_bucket.s3_bucket_arn,


### PR DESCRIPTION
# Summary
Adds the Notify Staging IAM role that will be used to perform cross-account reads of the RDS S3 exports. This will allow Notify to refresh their QuickSight data without a live read of the database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/897
