### PR TITLE
fix: allow Notify roles to use RDS export KMS key

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -104,6 +104,7 @@ data "aws_iam_policy_document" "raw_bucket" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::239043911459:role/datalake-reader-cross-account-role",
+        "arn:aws:iam::239043911459:role/service-role/aws-quicksight-service-role-v0",
       ]
     }
     actions = [

--- a/terragrunt/aws/export/platform/gc_notify/kms.tf
+++ b/terragrunt/aws/export/platform/gc_notify/kms.tf
@@ -42,8 +42,11 @@ data "aws_iam_policy_document" "platform_notify_rds_snapshot_exports_kms" {
     resources = ["*"]
 
     principals {
-      type        = "AWS"
-      identifiers = [local.gc_notify_rds_export_role_arn]
+      type = "AWS"
+      identifiers = concat(
+        [local.gc_notify_rds_export_role_arn],
+        local.gc_notify_quicksight_role_arns,
+      )
     }
 
     principals {

--- a/terragrunt/aws/export/platform/gc_notify/locals.tf
+++ b/terragrunt/aws/export/platform/gc_notify/locals.tf
@@ -6,4 +6,8 @@ locals {
   gc_notify_env                 = var.env
   gc_notify_lambda_name         = "platform-gc-notify-export"
   gc_notify_rds_export_role_arn = "arn:aws:iam::${local.gc_notify_account_id}:role/NotifyExportToPlatformDataLake"
+  gc_notify_quicksight_role_arns = [
+    "arn:aws:iam::239043911459:role/datalake-reader-cross-account-role",
+    "arn:aws:iam::239043911459:role/service-role/aws-quicksight-service-role-v0",
+  ]
 }


### PR DESCRIPTION
# Summary
Update the KMS key policy so that the Notify reader roles can decrypt the RDS snapshot exports.

Also update the Raw bucket policy to allow the QuickSight role to read objects.

# Related
- https://github.com/cds-snc/platform-core-services/issues/897