### PR TITLE
chore: remove default Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "vulnerabilityFixStrategy": "lowest"
-  },
   "extends": [
     "local>cds-snc/renovate-config"
   ]


### PR DESCRIPTION
# Summary
Remove config that has been added to the CDS org's default config.

# Related
- https://github.com/cds-snc/platform-core-services/issues/895
- https://github.com/cds-snc/renovate-config/pull/108