### PR TITLE
fix: commit files from new directories

### DIFF
--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -56,7 +56,6 @@ while IFS= read -r FILE; do
 done < <(git status --porcelain | awk '{print $2}')
 
 # Commit each file
-echo "Files to commit: ${ACTUAL_FILES[@]}"
 for FILE in "${ACTUAL_FILES[@]}"; do
     echo "Committing $FILE..."
     MESSAGE="chore: regenerate $(basename "$FILE") for $(date -u '+%Y-%m-%d')"


### PR DESCRIPTION
# Summary
Update the Glue job sync script to commit only the files from new
directories rather than attempting to commit the directory.