### PR TITLE
fix: remove qualtrics bucket policies

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -98,38 +98,6 @@ data "aws_iam_policy_document" "raw_bucket" {
   }
 
   statement {
-    sid    = "QualtricsExportToBucket"
-    effect = "Allow"
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.account_id}:role/QualtricsExportToDataLake",
-      ]
-    }
-    actions = [
-      "s3:DeleteObject",
-      "s3:GetObject",
-      "s3:PutObject",
-      "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
-      "s3:ListBucket",
-      "s3:GetBucketLocation"
-    ]
-    resources = [
-      "${module.raw_bucket.s3_bucket_arn}/operations/qualtrics/*"
-    ]
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-      values = [
-        "operations/qualtrics",
-        "operations/qualtrics/",
-        "operations/qualtrics/*"
-      ]
-    }
-  }
-
-  statement {
     sid    = "NotifyReadOnly"
     effect = "Allow"
     principals {


### PR DESCRIPTION
# Summary | Résumé

Removing bucket policies for qualtrics - might be redundant since it's already specified in IAM
