### PR TITLE
chore: add new Notify reader role

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -103,8 +103,8 @@ data "aws_iam_policy_document" "raw_bucket" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::239043911459:role/datalake-reader-cross-account-role",
         "arn:aws:iam::239043911459:role/service-role/aws-quicksight-service-role-v0",
+        "arn:aws:iam::296255494825:role/service-role/aws-quicksight-service-role-v0",
       ]
     }
     actions = [

--- a/terragrunt/aws/export/platform/gc_notify/locals.tf
+++ b/terragrunt/aws/export/platform/gc_notify/locals.tf
@@ -7,7 +7,7 @@ locals {
   gc_notify_lambda_name         = "platform-gc-notify-export"
   gc_notify_rds_export_role_arn = "arn:aws:iam::${local.gc_notify_account_id}:role/NotifyExportToPlatformDataLake"
   gc_notify_quicksight_role_arns = [
-    "arn:aws:iam::239043911459:role/datalake-reader-cross-account-role",
     "arn:aws:iam::239043911459:role/service-role/aws-quicksight-service-role-v0",
+    "arn:aws:iam::296255494825:role/service-role/aws-quicksight-service-role-v0",
   ]
 }


### PR DESCRIPTION
# Summary
Update the list of Notify IAM role ARNs that are allowed to read from the Notify RDS export.

# Related
- #500 