### PR TITLE
fix: missing superset access

### DIFF
--- a/terragrunt/aws/buckets/raw.tf
+++ b/terragrunt/aws/buckets/raw.tf
@@ -159,7 +159,7 @@ data "aws_iam_policy_document" "raw_bucket" {
       "s3:ListBucket"
     ]
     resources = [
-      module.raw_bucket.s3_bucket_arn,
+      "${module.raw_bucket.s3_bucket_arn}/operations/qualtrics",
       "${module.raw_bucket.s3_bucket_arn}/operations/qualtrics/*"
     ]
   }


### PR DESCRIPTION
# Summary | Résumé

Qualtrics data lives in the raw bucket - it doesn't need any transformations.

At the moment superset doesnt have the right creds to read from that s3
