### PR TITLE
fix: SBOM workflow permissions

### DIFF
--- a/.github/workflows/docker-sbom-staging.yml
+++ b/.github/workflows/docker-sbom-staging.yml
@@ -7,7 +7,7 @@ on:
     - completed
 
 permissions:
-  contents: read
+  contents: write
   
 jobs:
   docker-sbom:


### PR DESCRIPTION
# Summary
Allow the workflow to write the SBOM to the repo.

# Related
- https://github.com/cds-snc/platform-core-services/issues/970