### PR TITLE
fix: run Notify ETL and export after snapshot

### DIFF
--- a/terragrunt/aws/export/platform/gc_notify/locals.tf
+++ b/terragrunt/aws/export/platform/gc_notify/locals.tf
@@ -1,7 +1,7 @@
 locals {
   is_production = var.env == "production"
 
-  cron_expression               = local.is_production ? "cron(0 4 ? * * *)" : "cron(0 0 1 1 ? 1970)" # Daily at 4am UTC for prod, never otherwise
+  cron_expression               = local.is_production ? "cron(0 8 ? * * *)" : "cron(0 0 1 1 ? 1970)" # Daily at 8am UTC for prod, never otherwise
   gc_notify_account_id          = local.is_production ? "296255494825" : "239043911459"
   gc_notify_env                 = var.env
   gc_notify_lambda_name         = "platform-gc-notify-export"

--- a/terragrunt/aws/glue/etl.tf
+++ b/terragrunt/aws/glue/etl.tf
@@ -169,7 +169,7 @@ resource "aws_glue_job" "platform_gc_notify_job" {
 
 resource "aws_glue_trigger" "platform_gc_notify_job" {
   name     = "Platform / GC Notify"
-  schedule = "cron(0 7 * * ? *)" # Daily at 7am UTC
+  schedule = "cron(0 11 * * ? *)" # Daily at 11am UTC
   type     = "SCHEDULED"
   enabled  = false # Change for local.is_production to enable
 


### PR DESCRIPTION
# Summary 
The Notify database snapshot is now being created at 7am UTC (previously it was 2am UTC). This updates the export of that snapshot and ETL processing so that Superset's Notify dataset is up-to-date.
