### PR TITLE
fix: added GetFunctionConfiguration

### DIFF
--- a/terragrunt/aws/oidc/oidc.tf
+++ b/terragrunt/aws/oidc/oidc.tf
@@ -117,6 +117,7 @@ data "aws_iam_policy_document" "data_lake_docker_push" {
     sid = "LambdaUpdateFunctionCode"
     actions = [
       "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
       "lambda:UpdateFunctionCode",
     ]
     resources = [


### PR DESCRIPTION
# Summary | Résumé

Add lambda:GetFunctionConfiguration to the data-lake-docker-push policy.