### PR TITLE
fix: incremental date load start of day

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.4.3",
+      "resolved": "ghcr.io/devcontainers/features/terraform@sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7",
+      "integrity": "sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7"
+    }
+  }
+}

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data.py
@@ -468,7 +468,9 @@ def get_incremental_load_date_from(data_look_back_days: int) -> str:
     all data within the overwritten month partition(s) while respecting the data retention policy.
     """
     today = datetime.now()
-    month_start = (today - timedelta(days=data_look_back_days)).replace(day=1)
+    month_start = (today - timedelta(days=data_look_back_days)).replace(
+        day=1, hour=0, minute=0, second=0, microsecond=0
+    )
     return month_start.strftime("%Y-%m-%d %H:%M:%S")
 
 

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
@@ -415,15 +415,23 @@ def test_get_incremental_load_date_from(mock_datetime):
     import datetime as real_datetime
 
     mock_datetime.now.return_value = real_datetime.datetime(
-        2024, 5, 15, 12, 0, 0, tzinfo=real_datetime.timezone.utc
+        2024, 5, 15, 12, 34, 56, tzinfo=real_datetime.timezone.utc
     )
-    mock_datetime.timedelta = real_datetime.timedelta
 
     result = get_incremental_load_date_from(90)
-    assert result.startswith("2024-02-01")
+    assert result == "2024-02-01 00:00:00"
 
     result = get_incremental_load_date_from(30)
-    assert result.startswith("2024-04-01")
+    assert result == "2024-04-01 00:00:00"
+
+
+@patch("process_data.datetime")
+def test_get_incremental_load_date_from_month_boundary_regression(mock_datetime):
+    """Ensure day-1 records are included by using a midnight month-start cutoff."""
+    import datetime as real_datetime
+    mock_datetime.now.return_value = real_datetime.datetime(2024, 5, 3, 6, 15, 27)
+    result = get_incremental_load_date_from(14)
+    assert result == "2024-04-01 00:00:00"
 
 
 # ===== GREAT EXPECTATIONS VALIDATION TESTS =====

--- a/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/process_data_test.py
@@ -429,6 +429,7 @@ def test_get_incremental_load_date_from(mock_datetime):
 def test_get_incremental_load_date_from_month_boundary_regression(mock_datetime):
     """Ensure day-1 records are included by using a midnight month-start cutoff."""
     import datetime as real_datetime
+
     mock_datetime.now.return_value = real_datetime.datetime(2024, 5, 3, 6, 15, 27)
     result = get_incremental_load_date_from(14)
     assert result == "2024-04-01 00:00:00"

--- a/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
+++ b/terragrunt/aws/glue/etl/platform/gc_notify/tables/notification_history.json
@@ -3,7 +3,7 @@
   "partition_timestamp": "created_at",
   "partition_cols": ["year", "month"],
   "incremental_load": true,
-  "look_back_days": 14,
+  "look_back_days": 21,
   "fields": [
     {
       "name": "id",


### PR DESCRIPTION
# Summary
Update the incremental date load logic to set the start date time to midnight. This fixes a bug where all records at the first of the month with a time before the ETL job start time were being missed.

This also adds another 7 days to the `notification_history` look back period to give a safety buffer.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1014