### PR TITLE
fix: added missing version

### DIFF
--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -47,5 +47,7 @@ runs:
 
         - name: Output version
           id: output-version
+          env:
+            VERSION: ${{ steps.version-from-tag.outputs.VERSION || steps.version-from-branch.outputs.VERSION }}
           run: echo "version=${VERSION}" >> $GITHUB_OUTPUT  
           shell: bash


### PR DESCRIPTION
# Summary | Résumé

`$VERSION` was empty causing all Docker image tags to be invalid. Fixed by explicitly injecting the version.