### PR TITLE
fix: authenticate before branch push

### DIFF
--- a/.github/workflows/scripts/sync-glue-jobs.sh
+++ b/.github/workflows/scripts/sync-glue-jobs.sh
@@ -35,6 +35,7 @@ if ! git status --porcelain "$JOB_DIR" | grep -q "."; then
     exit 0
 else
     echo "Changes detected:"
+    gh auth setup-git
     git diff -- "$JOB_DIR"
     git push "$REMOTE_REPO" "$BRANCH_NAME"
 fi


### PR DESCRIPTION
# Summary
Update the sync job to authenticate before pushing the new branch. This is needed because of the `persist-credentials: false` change from zizmor.
