### PR TITLE
Trust org ID qualified subject claims for data export role

### DIFF
--- a/terragrunt/aws/oidc/oidc.tf
+++ b/terragrunt/aws/oidc/oidc.tf
@@ -11,13 +11,22 @@ locals {
 module "github_workflow_roles" {
   count = var.env == "production" ? 1 : 0
 
-  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v11.4.4"
+  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v11.4.5"
   billing_tag_value = var.billing_tag_value
   roles = [
     {
-      name      = local.data_lake_github_data_export
-      repo_name = "*" # Allow any CDS repo to use this role
-      claim     = "ref:refs/heads/main"
+      name = local.data_lake_github_data_export
+      claims = [
+        {
+          repo_name = "*" # Allow any CDS repo to use this role
+          claim     = "ref:refs/heads/main"
+        },
+        {
+          org_name  = "cds-snc@30166251" # Org ID qualified subject claim
+          repo_name = "*"
+          claim     = "ref:refs/heads/main"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Summary | Résumé

GitHub is moving to org ID qualified subject claims (`repo:cds-snc@30166251/...`)
in OIDC tokens. Workflows emitting the new format can no longer assume the
`data-lake-github-data-export` role, which only trusts `repo:cds-snc/*`.

Bumps `gh_oidc_role` to v11.4.5 and switches the role to the module's `claims`
list so it accepts both the existing and org ID qualified subjects during and
after the transition.

Resulting trust policy condition:

    "token.actions.githubusercontent.com:sub": [
        "repo:cds-snc/*:ref:refs/heads/main",
        "repo:cds-snc@30166251/*:ref:refs/heads/main"
    ]